### PR TITLE
feat: add KeyPath type for configuration keys

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,15 @@ linters:
           - wrapcheck
 
   settings:
+    varnamelen:
+      ignore-names:
+        - tt
+        - ok
+        - tb
+        - i
+      ignore-decls:
+        - mc *minimock.Controller
+        - t T
     godot:
       scope: all
     lll:
@@ -55,4 +64,5 @@ linters:
             - "$test"
           allow:
             - $gostd
-            - "github.com/stretchr/testify"
+            - "github.com/shoenig/test"
+            - "github.com/tarantool/go-config"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ coveralls-deps:
 .PHONY: lint-deps
 lint-deps:
 	@echo "Installing lint deps"
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.0
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
 
 .PHONY: lint
 lint: lint-deps

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/tarantool/go-config
 
 go 1.25
+
+require github.com/shoenig/test v1.12.2
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/shoenig/test v1.12.2 h1:ZVT8NeIUwGWpZcKaepPmFMoNQ3sVpxvqUh/MAqwFiJI=
+github.com/shoenig/test v1.12.2/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=

--- a/keypath.go
+++ b/keypath.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"slices"
+	"strings"
+)
+
+// KeyPath represents a hierarchical key.
+//
+// For example, for the key "/server/http/port" it will look like
+// []string{"server", "http", "port"}.
+type KeyPath []string
+
+// NewKeyPath creates a KeyPath from a string, splitting it by "/" slash.
+// This is the main way to create a path from a textual representation.
+func NewKeyPath(path string) KeyPath {
+	return NewKeyPathWithDelim(path, "/")
+}
+
+// NewKeyPathWithDelim creates a KeyPath from a string, splitting it by the given delimiter.
+// All segments are preserved, including empty ones.
+func NewKeyPathWithDelim(path, delim string) KeyPath {
+	if path == "" {
+		return KeyPath{}
+	}
+
+	return strings.Split(path, delim)
+}
+
+// String returns a textual representation of the path with slash ("/") as the delimiter.
+func (p KeyPath) String() string {
+	return p.MakeString("/")
+}
+
+// MakeString returns a textual representation of the path with the given delimiter.
+func (p KeyPath) MakeString(delim string) string {
+	return strings.Join(p, delim)
+}
+
+// Parent returns the parent path.
+// If the path consists of one element or is empty, returns nil.
+func (p KeyPath) Parent() KeyPath {
+	if len(p) <= 1 {
+		return nil
+	}
+
+	return p[:len(p)-1]
+}
+
+// Leaf returns the last segment of the path.
+// If the path is empty, returns an empty string.
+func (p KeyPath) Leaf() string {
+	if len(p) == 0 {
+		return ""
+	}
+
+	return p[len(p)-1]
+}
+
+// Append adds new segment(s) to the path, returning a new KeyPath.
+// The original path is not changed (immutability).
+func (p KeyPath) Append(segments ...string) KeyPath {
+	if len(segments) == 0 {
+		return p
+	}
+
+	newPath := make(KeyPath, 0, len(p)+len(segments))
+
+	newPath = append(append(newPath, p...), segments...)
+
+	return newPath
+}
+
+// Equals checks that two paths are completely identical.
+func (p KeyPath) Equals(other KeyPath) bool {
+	if len(p) != len(other) {
+		return false
+	}
+
+	for i := range p {
+		if p[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Match checks whether the path matches a pattern using wildcards.
+// A wildcard is "*", which matches any single segment.
+// A double wildcard "**" matches zero or more segments.
+// Pattern matches if it is a prefix of the path (pattern length <= path length).
+// For example, pattern "a/*/c" matches path "a/b/c".
+// Pattern "a/*/c" also matches path "a/b/c/d" (since pattern is prefix).
+// Pattern "a/**/c" matches path "a/b/c", "a/x/y/c", and "a/c".
+func (p KeyPath) Match(pattern KeyPath) bool {
+	var (
+		pointerI          = 0
+		pointerJ          = 0
+		backtrackPointerI = -1
+		backtrackPointerJ = -1
+	)
+
+	for pointerI < len(p) && pointerJ < len(pattern) {
+		seg := pattern[pointerJ]
+		if seg == "*" {
+			pointerI++
+
+			pointerJ++
+
+			continue
+		}
+
+		if seg == "**" {
+			backtrackPointerI = pointerI
+			backtrackPointerJ = pointerJ
+			pointerJ++
+
+			continue
+		}
+
+		if seg == p[pointerI] {
+			pointerI++
+
+			pointerJ++
+
+			continue
+		}
+
+		if backtrackPointerJ >= 0 {
+			pointerI = backtrackPointerI + 1
+			pointerJ = backtrackPointerJ
+			backtrackPointerI = pointerI
+
+			continue
+		}
+
+		return false
+	}
+
+	for pointerJ < len(pattern) && pattern[pointerJ] == "**" {
+		pointerJ++
+	}
+
+	return pointerJ == len(pattern)
+}
+
+// HasEmptySegment returns true if the path contains any empty segment ("").
+func (p KeyPath) HasEmptySegment() bool {
+	return slices.Contains(p, "")
+}

--- a/keypath_test.go
+++ b/keypath_test.go
@@ -1,0 +1,303 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shoenig/test"
+
+	"github.com/tarantool/go-config"
+)
+
+func formatTestName(in string) string {
+	return strings.ReplaceAll(in, "/", "_")
+}
+
+func TestNewKeyPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected config.KeyPath
+	}{
+		{"", config.KeyPath{}},
+		{"a", config.KeyPath{"a"}},
+		{"a/b", config.KeyPath{"a", "b"}},
+		{"a/b/c", config.KeyPath{"a", "b", "c"}},
+		{"/a/b", config.KeyPath{"", "a", "b"}},
+		{"a//c", config.KeyPath{"a", "", "c"}},
+		{"a/", config.KeyPath{"a", ""}},
+		{"/", config.KeyPath{"", ""}},
+		{"//a//b//", config.KeyPath{"", "", "a", "", "b", "", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.input), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, config.NewKeyPath(tt.input))
+			// Equal method works the same way as eq comparison.
+			test.True(t, config.NewKeyPath(tt.input).Equals(tt.expected))
+		})
+	}
+}
+
+func TestNewKeyPathWithDelim(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		delim    string
+		expected config.KeyPath
+	}{
+		{"a.b.c", ".", config.KeyPath{"a", "b", "c"}},
+		{"a..c", ".", config.KeyPath{"a", "", "c"}},
+		{"a|b", "|", config.KeyPath{"a", "b"}},
+		{"", ".", config.KeyPath{}},
+		{".a.b.", ".", config.KeyPath{"", "a", "b", ""}},
+		{"..a..b..", ".", config.KeyPath{"", "", "a", "", "b", "", ""}},
+		{"|a||b|", "|", config.KeyPath{"", "a", "", "b", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.input), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, config.NewKeyPathWithDelim(tt.input, tt.delim))
+			// Equal method works the same way as eq comparison.
+			test.True(t, config.NewKeyPathWithDelim(tt.input, tt.delim).Equals(tt.expected))
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		expected string
+	}{
+		{config.KeyPath{}, ""},
+		{config.KeyPath{"a"}, "a"},
+		{config.KeyPath{"a", "b"}, "a/b"},
+		{config.KeyPath{"", "a", "b"}, "/a/b"},
+		{config.KeyPath{"a", "", "c"}, "a//c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.String())
+		})
+	}
+}
+
+func TestMakeString(t *testing.T) {
+	t.Parallel()
+
+	path := config.KeyPath{"a", "b", "c"}
+	test.Eq(t, "a.b.c", path.MakeString("."))
+	test.Eq(t, "a|b|c", path.MakeString("|"))
+}
+
+func TestParent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		expected config.KeyPath
+	}{
+		{config.KeyPath{}, nil},
+		{config.KeyPath{"a"}, nil},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a"}},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Parent())
+		})
+	}
+}
+
+func TestLeaf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		expected string
+	}{
+		{config.KeyPath{}, ""},
+		{config.KeyPath{"a"}, "a"},
+		{config.KeyPath{"a", "b"}, "b"},
+		{config.KeyPath{"a", "b", "c"}, "c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path.String(), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Leaf())
+		})
+	}
+}
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+
+	path := config.KeyPath{"a", "b"}
+	got := path.Append("c", "d")
+
+	test.Eq(t, config.KeyPath{"a", "b", "c", "d"}, got)
+	// Original KeyPath is unchanged.
+	test.Eq(t, config.KeyPath{"a", "b"}, path)
+}
+
+func TestEquals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		a        config.KeyPath
+		b        config.KeyPath
+		expected bool
+	}{
+		{config.KeyPath{}, config.KeyPath{}, true},
+		{config.KeyPath{"a"}, config.KeyPath{"a"}, true},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "b"}, true},
+		{config.KeyPath{"a"}, config.KeyPath{"b"}, false},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a"}, false},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.a.String()+"_"+tt.b.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.a.Equals(tt.b))
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		pattern  config.KeyPath
+		expected bool
+	}{
+		// Exact matches.
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b", "c"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b", "d"}, false},
+		// Wildcard as "*".
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "*", "c"}, true},
+		{config.KeyPath{"a", "x", "c"}, config.KeyPath{"a", "*", "c"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"*", "b", "c"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b", "*"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"*", "*", "*"}, true},
+		// Empty segment is NOT a wildcard.
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "", "c"}, false},
+		{config.KeyPath{"a", "x", "c"}, config.KeyPath{"a", "", "c"}, false},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"", "b", "c"}, false},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b", ""}, false},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"", "", ""}, false},
+		// Length mismatch: pattern shorter than path (prefix match).
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "b"}, true},
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"a", "b"}, true},
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"a", "*"}, true},
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"*", "b"}, true},
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"a", "*", "c"}, true},
+		// Length mismatch: pattern longer than path.
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "b", "c"}, false},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "b", "*"}, false},
+		// Multiple wildcards.
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"a", "*", "c", "*"}, true},
+		{config.KeyPath{"a", "x", "c", "y"}, config.KeyPath{"a", "*", "c", "*"}, true},
+		{config.KeyPath{"a", "x", "c", "y"}, config.KeyPath{"a", "*", "d", "*"}, false},
+		// Empty path and pattern.
+		{config.KeyPath{}, config.KeyPath{}, true},
+		{config.KeyPath{}, config.KeyPath{""}, false},
+		{config.KeyPath{""}, config.KeyPath{}, true},
+		{config.KeyPath{"a"}, config.KeyPath{}, true},
+		// RFC example: pattern "/groups/*/replicasets/*/instances" should match path with extra segments.
+		{config.KeyPath{"groups", "storages", "replicasets", "storage-001", "instances", "storage-001-a"},
+			config.KeyPath{"groups", "*", "replicasets", "*", "instances"}, true},
+		{config.KeyPath{"groups", "storages", "replicasets", "storage-001", "instances"},
+			config.KeyPath{"groups", "*", "replicasets", "*", "instances"}, true},
+		{config.KeyPath{"groups", "storages", "replicasets", "storage-001"},
+			config.KeyPath{"groups", "*", "replicasets", "*", "instances"}, false},
+		// Wildcard * should match exactly one segment.
+		{config.KeyPath{"a", "c", "d", "b"}, config.KeyPath{"a", "*", "b"}, false},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "*", "b"}, false},
+		{config.KeyPath{"a"}, config.KeyPath{"a", "*"}, false},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"*", "b"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"*", "b", "*"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()+"_"+tt.pattern.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Match(tt.pattern))
+		})
+	}
+}
+
+func TestHasEmptySegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		expected bool
+	}{
+		{config.KeyPath{}, false},
+		{config.KeyPath{"a"}, false},
+		{config.KeyPath{"a", "b", "c"}, false},
+		{config.KeyPath{"a", "", "c"}, true},
+		{config.KeyPath{"", "a", "b"}, true},
+		{config.KeyPath{"a", "b", ""}, true},
+		{config.KeyPath{"", "", ""}, true},
+		{config.KeyPath{"", "a", "", "b", ""}, true},
+		{config.NewKeyPath("a//c"), true},
+		{config.NewKeyPath("/a/b"), true},
+		{config.NewKeyPath("a/"), true},
+		{config.NewKeyPath("//a//b//"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.HasEmptySegment())
+		})
+	}
+}
+
+func TestMatchDoubleStar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     config.KeyPath
+		pattern  config.KeyPath
+		expected bool
+	}{
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "**", "b"}, true},
+		{config.KeyPath{"a", "x", "b"}, config.KeyPath{"a", "**", "b"}, true},
+		{config.KeyPath{"a", "x", "y", "z", "b"}, config.KeyPath{"a", "**", "b"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"a", "**"}, true},
+		{config.KeyPath{"a", "b", "c"}, config.KeyPath{"**", "c"}, true},
+		{config.KeyPath{"a", "b", "c", "d"}, config.KeyPath{"a", "*", "**", "d"}, true},
+		{config.KeyPath{"a", "b", "c", "d", "e"}, config.KeyPath{"a", "**", "c", "**", "e"}, true},
+		{config.KeyPath{"a", "b"}, config.KeyPath{"a", "**", "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()+"_"+tt.pattern.String()), func(t *testing.T) {
+			t.Parallel()
+			test.Eq(t, tt.expected, tt.path.Match(tt.pattern))
+		})
+	}
+}


### PR DESCRIPTION
Add a new KeyPath type that represents configuration keys with support for path manipulation, pattern matching with wildcards.

Closes TNTP-5711