### PR TITLE
api: configuration tree implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,7 @@ linters:
         - ok
         - tb
         - i
+        - m
       ignore-decls:
         - mc *minimock.Controller
         - t T
@@ -59,6 +60,8 @@ linters:
             - "!$test"
           allow:
             - $gostd
+            - "github.com/shoenig/test"
+            - "github.com/tarantool/go-config"
         test:
           files:
             - "$test"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ coveralls-deps:
 .PHONY: lint-deps
 lint-deps:
 	@echo "Installing lint deps"
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 
 .PHONY: lint
 lint: lint-deps

--- a/internal/omap/orderedmap.go
+++ b/internal/omap/orderedmap.go
@@ -1,0 +1,143 @@
+// Package omap provides an ordered map implementation that maintains insertion order.
+package omap
+
+import "iter"
+
+// OrderedMap maintains key-value pairs with insertion order preservation.
+type OrderedMap[K comparable, V any] struct {
+	order []K
+	items map[K]V
+}
+
+// New creates an empty OrderedMap.
+func New[K comparable, V any]() *OrderedMap[K, V] {
+	return &OrderedMap[K, V]{
+		order: nil,
+		items: nil,
+	}
+}
+
+// NewWithCapacity creates an empty OrderedMap with preallocated capacity.
+func NewWithCapacity[K comparable, V any](capacity int) *OrderedMap[K, V] {
+	return &OrderedMap[K, V]{
+		order: make([]K, 0, capacity),
+		items: make(map[K]V, capacity),
+	}
+}
+
+// Set sets the value for the given key.
+// If the key is new, it is appended to the end of the order.
+// If the key already exists, its value is updated and the order remains unchanged.
+func (m *OrderedMap[K, V]) Set(key K, value V) {
+	if m.items == nil {
+		m.items = make(map[K]V)
+		m.order = []K{}
+	}
+
+	if _, exists := m.items[key]; !exists {
+		m.order = append(m.order, key)
+	}
+
+	m.items[key] = value
+}
+
+// Get returns the value associated with the key, and a boolean indicating whether the key exists.
+func (m *OrderedMap[K, V]) Get(key K) (V, bool) {
+	if m.items == nil {
+		var zero V
+		return zero, false
+	}
+
+	value, ok := m.items[key]
+
+	return value, ok
+}
+
+// Has returns true if the key exists in the map.
+func (m *OrderedMap[K, V]) Has(key K) bool {
+	if m.items == nil {
+		return false
+	}
+
+	_, ok := m.items[key]
+
+	return ok
+}
+
+// Delete removes the key-value pair from the map.
+// It returns true if the key was present and removed.
+func (m *OrderedMap[K, V]) Delete(key K) bool {
+	if m.items == nil {
+		return false
+	}
+
+	if _, exists := m.items[key]; !exists {
+		return false
+	}
+
+	delete(m.items, key)
+
+	// Remove from order.
+	for i, k := range m.order {
+		if k == key {
+			m.order = append(m.order[:i], m.order[i+1:]...)
+			break
+		}
+	}
+
+	return true
+}
+
+// Len returns the number of key-value pairs in the map.
+func (m *OrderedMap[K, V]) Len() int {
+	if m.items == nil {
+		return 0
+	}
+
+	return len(m.items)
+}
+
+// Keys returns an iterator over keys in insertion order.
+func (m *OrderedMap[K, V]) Keys() iter.Seq[K] {
+	return func(yield func(K) bool) {
+		for _, key := range m.order {
+			if _, ok := m.items[key]; ok {
+				if !yield(key) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Values returns an iterator over values in insertion order.
+func (m *OrderedMap[K, V]) Values() iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for _, key := range m.order {
+			if value, ok := m.items[key]; ok {
+				if !yield(value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Items returns an iterator over key-value pairs in insertion order.
+func (m *OrderedMap[K, V]) Items() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		for _, key := range m.order {
+			if value, ok := m.items[key]; ok {
+				if !yield(key, value) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Clear removes all key-value pairs from the map.
+func (m *OrderedMap[K, V]) Clear() {
+	m.order = nil
+	m.items = nil
+}

--- a/internal/omap/orderedmap_test.go
+++ b/internal/omap/orderedmap_test.go
@@ -1,0 +1,418 @@
+package omap_test
+
+import (
+	"testing"
+
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+
+	"github.com/tarantool/go-config/internal/omap"
+	"github.com/tarantool/go-config/internal/testutil"
+)
+
+func TestOrderedMap_Set_Get_single(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+
+	val, ok := m.Get("a")
+	must.True(t, ok)
+	test.Eq(t, 1, val)
+}
+
+func TestOrderedMap_Set_Get_multiple(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Set("c", 3)
+
+	val, ok := m.Get("a")
+	must.True(t, ok)
+	test.Eq(t, 1, val)
+
+	val, ok = m.Get("b")
+	must.True(t, ok)
+	test.Eq(t, 2, val)
+
+	val, ok = m.Get("c")
+	must.True(t, ok)
+	test.Eq(t, 3, val)
+}
+
+func TestOrderedMap_Set_Get_missing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Set("c", 3)
+
+	_, ok := m.Get("missing")
+	test.False(t, ok)
+}
+
+func TestOrderedMap_Set_Overwrite_value(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, string]()
+	m.Set("key", "first")
+
+	val, ok := m.Get("key")
+	must.True(t, ok)
+	test.Eq(t, "first", val)
+
+	m.Set("key", "second")
+
+	val, ok = m.Get("key")
+	must.True(t, ok)
+	test.Eq(t, "second", val)
+}
+
+func TestOrderedMap_Set_Overwrite_order(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, string]()
+	m.Set("key", "first")
+	m.Set("key", "second")
+
+	testutil.TestIterSeqCompare(t, []string{"key"}, m.Keys())
+}
+
+func TestOrderedMap_Delete_existing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Set("c", 3)
+
+	ok := m.Delete("b")
+	must.True(t, ok)
+	testutil.TestIterSeqLen(t, 2, m.Keys())
+
+	_, ok = m.Get("b")
+	test.False(t, ok)
+
+	// Order should be a, c.
+	testutil.TestIterSeqCompare(t, []string{"a", "c"}, m.Keys())
+}
+
+func TestOrderedMap_Delete_missing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Set("c", 3)
+
+	ok := m.Delete("missing")
+	test.False(t, ok)
+}
+
+func TestOrderedMap_Len_initial(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	test.Length(t, 0, m)
+}
+
+func TestOrderedMap_Len_afterSet(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	test.Length(t, 1, m)
+}
+
+func TestOrderedMap_Len_afterMultipleSet(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	test.Length(t, 2, m)
+}
+
+func TestOrderedMap_Len_afterDelete(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Delete("a")
+	test.Length(t, 1, m)
+}
+
+func TestOrderedMap_Len_afterClear(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+	m.Clear()
+	test.Length(t, 0, m)
+}
+
+func TestOrderedMap_Keys_empty(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeqEmpty(t, m.Keys())
+}
+
+func TestOrderedMap_Keys_single(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("x", 10)
+	testutil.TestIterSeqCompare(t, []string{"x"}, m.Keys())
+}
+
+func TestOrderedMap_Keys_multiple(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("x", 10)
+	m.Set("y", 20)
+	m.Set("z", 30)
+
+	testutil.TestIterSeqCompare(t, []string{"x", "y", "z"}, m.Keys())
+}
+
+func TestOrderedMap_Values_empty(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeqEmpty(t, m.Values())
+}
+
+func TestOrderedMap_Values_single(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 100)
+	testutil.TestIterSeqCompare(t, []int{100}, m.Values())
+}
+
+func TestOrderedMap_Values_multiple(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 100)
+	m.Set("b", 200)
+	m.Set("c", 300)
+
+	testutil.TestIterSeqCompare(t, []int{100, 200, 300}, m.Values())
+}
+
+func TestOrderedMap_Items_empty(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeq2Empty(t, m.Items())
+}
+
+func TestOrderedMap_Items_single(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("first", 1)
+
+	expected := []testutil.TestIterSeq2Pair[string, int]{
+		{Key: "first", Value: 1},
+	}
+	testutil.TestIterSeq2Compare(t, expected, m.Items())
+}
+
+func TestOrderedMap_Items_multiple(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("first", 1)
+	m.Set("second", 2)
+
+	expected := []testutil.TestIterSeq2Pair[string, int]{
+		{Key: "first", Value: 1}, {Key: "second", Value: 2},
+	}
+	testutil.TestIterSeq2Compare(t, expected, m.Items())
+}
+
+func TestOrderedMap_Clear_empties(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	m.Clear()
+	test.Length(t, 0, m)
+	testutil.TestIterSeqEmpty(t, m.Keys())
+	testutil.TestIterSeqEmpty(t, m.Values())
+}
+
+func TestOrderedMap_Clear_canSetAgain(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+	m.Set("b", 2)
+
+	m.Clear()
+	m.Set("c", 3)
+	test.Length(t, 1, m)
+	testutil.TestIterSeqCompare(t, []string{"c"}, m.Keys())
+}
+
+func TestOrderedMap_NewWithCapacity_initial(t *testing.T) {
+	t.Parallel()
+
+	m := omap.NewWithCapacity[string, int](10)
+	test.Length(t, 0, m)
+}
+
+func TestOrderedMap_NewWithCapacity_afterSet(t *testing.T) {
+	t.Parallel()
+
+	m := omap.NewWithCapacity[string, int](10)
+	m.Set("a", 1)
+	m.Set("b", 2)
+	test.Length(t, 2, m)
+}
+
+func TestOrderedMap_NewWithCapacity_zero(t *testing.T) {
+	t.Parallel()
+
+	m := omap.NewWithCapacity[string, int](0)
+	test.Length(t, 0, m)
+	m.Set("a", 1)
+	test.Length(t, 1, m)
+}
+
+func TestOrderedMap_OrderPreservation_SetExisting(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	// Insert existing key, order unchanged.
+	m.Set("y", 99)
+
+	testutil.TestIterSeqCompare(t, []string{"z", "y", "x"}, m.Keys())
+
+	val, ok := m.Get("y")
+	must.True(t, ok)
+	test.Eq(t, 99, val)
+}
+
+func TestOrderedMap_OrderPreservation_DeleteMiddle(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	m.Delete("y")
+	testutil.TestIterSeqCompare(t, []string{"z", "x"}, m.Keys())
+}
+
+func TestOrderedMap_OrderPreservation_AddNew(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	m.Delete("y")
+	m.Set("w", 4)
+	testutil.TestIterSeqCompare(t, []string{"z", "x", "w"}, m.Keys())
+}
+
+func TestOrderedMap_OrderPreservation_DeleteFirst(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	m.Delete("z")
+	testutil.TestIterSeqCompare(t, []string{"y", "x"}, m.Keys())
+}
+
+func TestOrderedMap_OrderPreservation_DeleteLast(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	m.Delete("x")
+	testutil.TestIterSeqCompare(t, []string{"z", "y"}, m.Keys())
+}
+
+func TestOrderedMap_OrderPreservation_DeleteAllThenAdd(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("z", 1)
+	m.Set("y", 2)
+	m.Set("x", 3)
+
+	m.Delete("z")
+	m.Delete("y")
+	m.Delete("x")
+	testutil.TestIterSeqEmpty(t, m.Keys())
+
+	m.Set("a", 4)
+	m.Set("b", 5)
+	m.Set("c", 6)
+	testutil.TestIterSeqCompare(t, []string{"a", "b", "c"}, m.Keys())
+}
+
+func TestOrderedMap_Has_true(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+
+	must.True(t, m.Has("a"))
+}
+
+func TestOrderedMap_Has_false(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	m.Set("a", 1)
+
+	test.False(t, m.Has("b"))
+}
+
+func TestOrderedMap_EmptyMapBehavior_GetMissing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	_, ok := m.Get("anything")
+	test.False(t, ok)
+}
+
+func TestOrderedMap_EmptyMapBehavior_HasMissing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	test.False(t, m.Has("anything"))
+}
+
+func TestOrderedMap_EmptyMapBehavior_DeleteMissing(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	test.False(t, m.Delete("anything"))
+}

--- a/internal/testutil/seq.go
+++ b/internal/testutil/seq.go
@@ -1,0 +1,37 @@
+// Package testutil provides test helpers for working with Go iterators (iter.Seq and iter.Seq2).
+// These helpers simplify comparing iterator outputs with expected slices, checking emptiness,
+// and verifying lengths in tests.
+package testutil
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/shoenig/test"
+)
+
+// TestIterSeqCompare compares the output of an iter.Seq with an expected slice.
+// It collects the iterator into a slice and uses test.Eq to assert equality.
+// This is useful for testing functions that return iter.Seq.
+func TestIterSeqCompare[V any](t *testing.T, expected []V, it iter.Seq[V]) {
+	t.Helper()
+
+	test.Eq(t, expected, slices.Collect(it))
+}
+
+// TestIterSeqEmpty asserts that an iter.Seq produces no elements.
+// It collects the iterator and uses test.SliceEmpty to verify the slice is empty.
+func TestIterSeqEmpty[V any](t *testing.T, it iter.Seq[V]) {
+	t.Helper()
+
+	test.SliceEmpty(t, slices.Collect(it))
+}
+
+// TestIterSeqLen asserts that an iter.Seq produces exactly the expected number of elements.
+// It collects the iterator and uses test.SliceLen to verify the length.
+func TestIterSeqLen[V any](t *testing.T, expected int, it iter.Seq[V]) {
+	t.Helper()
+
+	test.SliceLen(t, expected, slices.Collect(it))
+}

--- a/internal/testutil/seq2.go
+++ b/internal/testutil/seq2.go
@@ -1,0 +1,70 @@
+package testutil
+
+import (
+	"iter"
+	"slices"
+	"testing"
+
+	"github.com/shoenig/test"
+)
+
+// TestIterSeq2Pair holds a key-value pair from an iter.Seq2 iterator.
+// Used to convert iter.Seq2 outputs into slices for comparison.
+type TestIterSeq2Pair[K any, V any] struct {
+	Key   K
+	Value V
+}
+
+// testSeq2ToSeq converts an iter.Seq2[K, V] into an iter.Seq[TestIterSeq2Pair[K, V]].
+// This internal helper allows collecting key-value pairs into a slice for comparisons.
+func testSeq2ToSeq[K any, V any](it iter.Seq2[K, V]) iter.Seq[TestIterSeq2Pair[K, V]] {
+	return func(yield func(TestIterSeq2Pair[K, V]) bool) {
+		for key, val := range it {
+			if !yield(TestIterSeq2Pair[K, V]{Key: key, Value: val}) {
+				return
+			}
+		}
+	}
+}
+
+// testSeq2ToSlice collects an iter.Seq2[K, V] into a slice of TestIterSeq2Pair[K, V].
+// This internal helper is used by the TestIterSeq2* functions.
+func testSeq2ToSlice[K any, V any](it iter.Seq2[K, V]) []TestIterSeq2Pair[K, V] {
+	return slices.Collect(testSeq2ToSeq(it))
+}
+
+// TestIterSeq2Compare compares the output of an iter.Seq2 with an expected slice of key-value pairs.
+// It converts the iterator into a slice of TestIterSeq2Pair and uses test.Eq to assert equality.
+// Order does matter.
+// Useful for testing functions that return iter.Seq2.
+func TestIterSeq2Compare[K any, V any](t *testing.T, expected []TestIterSeq2Pair[K, V], it iter.Seq2[K, V]) {
+	t.Helper()
+
+	test.Eq(t, expected, testSeq2ToSlice(it))
+}
+
+// TestIterSeq2UnorderedCompare compares the output of an iter.Seq2 with an expected slice of key-value pairs.
+// It converts the iterator into a slice of TestIterSeq2Pair and uses test.Eq to assert equality.
+// Order doesn't matter.
+// Useful for testing functions that return iter.Seq2.
+func TestIterSeq2UnorderedCompare[K any, V any](t *testing.T, expected []TestIterSeq2Pair[K, V], it iter.Seq2[K, V]) {
+	t.Helper()
+
+	test.SliceContainsAll(t, expected, testSeq2ToSlice(it))
+}
+
+// TestIterSeq2Empty asserts that an iter.Seq2 produces no elements.
+// It converts the iterator into a slice of pairs and uses test.SliceEmpty to verify emptiness.
+func TestIterSeq2Empty[K any, V any](t *testing.T, it iter.Seq2[K, V]) {
+	t.Helper()
+
+	test.SliceEmpty(t, testSeq2ToSlice(it))
+}
+
+// TestIterSeq2Len asserts that an iter.Seq2 produces exactly the expected number of key-value pairs.
+// It converts the iterator into a slice of pairs and uses test.SliceLen to verify the length.
+func TestIterSeq2Len[K any, V any](t *testing.T, expected int, it iter.Seq2[K, V]) {
+	t.Helper()
+
+	test.SliceLen(t, expected, testSeq2ToSlice(it))
+}

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -1,0 +1,143 @@
+// Package tree provides an in-memory configuration tree with ordered children.
+package tree
+
+import (
+	"slices"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/internal/omap"
+)
+
+// Value represents a configuration value.
+type Value any
+
+// Node represents a node in the configuration tree.
+type Node struct {
+	// Value holds the node's value if it's a leaf node.
+	Value Value
+
+	// Source indicates where this node's value came from (e.g., file, env, flag).
+	Source string
+
+	// Revision is a version identifier for the node (e.g., commit hash, timestamp).
+	Revision string
+
+	// children is an ordered map from child keys to their nodes.
+	children *omap.OrderedMap[string, *Node]
+}
+
+// New creates a new empty node.
+func New() *Node {
+	return &Node{
+		Value:    nil,
+		Source:   "",
+		Revision: "",
+		children: nil,
+	}
+}
+
+// IsLeaf returns true if the node has no children.
+func (n *Node) IsLeaf() bool {
+	if n.children == nil {
+		return true
+	}
+
+	return n.children.Len() == 0
+}
+
+// Children returns the child nodes in insertion order.
+func (n *Node) Children() []*Node {
+	if n.children == nil {
+		return nil
+	}
+
+	return slices.Collect(n.children.Values())
+}
+
+// ChildrenKeys returns the keys of child nodes in insertion order.
+func (n *Node) ChildrenKeys() []string {
+	if n.children == nil {
+		return nil
+	}
+
+	return slices.Collect(n.children.Keys())
+}
+
+// Child returns the child node for the given key, or nil if not found.
+func (n *Node) Child(key string) *Node {
+	if n.children == nil {
+		return nil
+	}
+
+	child, ok := n.children.Get(key)
+	if !ok {
+		return nil
+	}
+
+	return child
+}
+
+// SetChild sets or replaces a child node under the given key.
+// If a child with this key already exists, it is replaced and the insertion order is preserved.
+// If the child is new, it is appended to the end of the order.
+func (n *Node) SetChild(key string, child *Node) {
+	if n.children == nil {
+		n.children = omap.New[string, *Node]()
+	}
+
+	n.children.Set(key, child)
+}
+
+// DeleteChild removes a child node by key.
+// It also removes the key from the insertion order.
+func (n *Node) DeleteChild(key string) bool {
+	if n.children == nil {
+		return false
+	}
+
+	return n.children.Delete(key)
+}
+
+// Set sets the value at the given path, creating intermediate nodes as needed.
+func (n *Node) Set(path config.KeyPath, value Value) {
+	if len(path) == 0 {
+		n.Value = value
+		return
+	}
+
+	key := path[0]
+
+	child := n.Child(key)
+	if child == nil {
+		child = New()
+		n.SetChild(key, child)
+	}
+
+	child.Set(path[1:], value)
+}
+
+// Get returns the node at the given path, or nil if not found.
+func (n *Node) Get(path config.KeyPath) *Node {
+	if len(path) == 0 {
+		return n
+	}
+
+	key := path[0]
+
+	child := n.Child(key)
+	if child == nil {
+		return nil
+	}
+
+	return child.Get(path[1:])
+}
+
+// GetValue returns the value at the given path, or nil if not found or node is not a leaf.
+func (n *Node) GetValue(path config.KeyPath) Value {
+	node := n.Get(path)
+	if node == nil || !node.IsLeaf() {
+		return nil
+	}
+
+	return node.Value
+}

--- a/internal/tree/node_test.go
+++ b/internal/tree/node_test.go
@@ -1,0 +1,465 @@
+package tree_test
+
+import (
+	"testing"
+
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/internal/tree"
+)
+
+func TestNode_Set_Get_leaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Set(config.NewKeyPath("a/b/c"), 42)
+	root.Set(config.NewKeyPath("a/b/d"), "hello")
+	root.Set(config.NewKeyPath("x/y"), true)
+
+	node := root.Get(config.NewKeyPath("a/b/c"))
+	must.NotNil(t, node)
+	test.True(t, node.IsLeaf())
+	test.Eq(t, 42, node.Value)
+
+	node = root.Get(config.NewKeyPath("a/b/d"))
+	must.NotNil(t, node)
+	test.Eq(t, "hello", node.Value)
+
+	node = root.Get(config.NewKeyPath("x/y"))
+	must.NotNil(t, node)
+	test.Eq(t, true, node.Value)
+}
+
+func TestNode_Set_Get_nonLeaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Set(config.NewKeyPath("a/b/c"), 42)
+	root.Set(config.NewKeyPath("a/b/d"), "hello")
+	root.Set(config.NewKeyPath("x/y"), true)
+
+	node := root.Get(config.NewKeyPath("a/b"))
+	must.NotNil(t, node)
+	test.False(t, node.IsLeaf())
+}
+
+func TestNode_Set_Get_missing(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Set(config.NewKeyPath("a/b/c"), 42)
+	root.Set(config.NewKeyPath("a/b/d"), "hello")
+	root.Set(config.NewKeyPath("x/y"), true)
+
+	node := root.Get(config.NewKeyPath("nonexistent"))
+	test.Nil(t, node)
+}
+
+func TestNode_Get_emptyPath(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Value = "test value"
+
+	node := root.Get(config.KeyPath{})
+	must.NotNil(t, node)
+	test.Eq(t, "test value", node.Value)
+}
+
+func TestNode_IsLeaf_true(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	test.True(t, node.IsLeaf())
+}
+
+func TestNode_IsLeaf_false(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.SetChild("child", tree.New())
+	test.False(t, node.IsLeaf())
+}
+
+func TestNode_IsLeaf_withValue(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+
+	node.Value = "some value"
+	test.True(t, node.IsLeaf())
+}
+
+func TestNode_IsLeaf_nilValue(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+
+	node.Value = nil
+	test.True(t, node.IsLeaf())
+}
+
+func TestNode_IsLeaf_childrenInitializedButEmpty(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.SetChild("child", tree.New())
+	node.DeleteChild("child")
+	test.True(t, node.IsLeaf())
+}
+
+func TestNode_Child_existing(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	child := tree.New()
+
+	child.Value = "child value"
+	node.SetChild("key", child)
+
+	result := node.Child("key")
+	must.NotNil(t, result)
+	test.Eq(t, "child value", result.Value)
+}
+
+func TestNode_Child_missing(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.SetChild("other", tree.New())
+
+	result := node.Child("missing")
+	test.Nil(t, result)
+}
+
+func TestNode_Child_nilChildren(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	result := node.Child("any")
+	test.Nil(t, result)
+}
+
+func TestNode_GetValue_leaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/b"), 100)
+
+	val := root.GetValue(config.NewKeyPath("a/b"))
+	test.Eq(t, 100, val)
+}
+
+func TestNode_GetValue_nonLeaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/b"), 100)
+
+	val := root.GetValue(config.NewKeyPath("a"))
+	test.Nil(t, val)
+}
+
+func TestNode_GetValue_missing(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/b"), 100)
+
+	val := root.GetValue(config.NewKeyPath("missing"))
+	test.Nil(t, val)
+}
+
+func TestNode_Set_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/b"), "first")
+	root.Set(config.NewKeyPath("a/b"), "second")
+
+	node := root.Get(config.NewKeyPath("a/b"))
+	must.NotNil(t, node)
+	test.Eq(t, "second", node.Value)
+}
+
+func TestNode_Set_overwriteLeafToNonLeaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a"), "value")
+
+	node := root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, node)
+	test.Eq(t, "value", node.Value)
+	test.True(t, node.IsLeaf())
+
+	node.SetChild("b", tree.New())
+
+	node = root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, node)
+	test.Eq(t, "value", node.Value)
+	test.False(t, node.IsLeaf())
+}
+
+func TestNode_Set_overwriteNonLeafToLeaf(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+
+	nodeA := root.Child("a")
+	nodeA.SetChild("b", tree.New())
+
+	node := root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, node)
+	test.False(t, node.IsLeaf())
+
+	root.Set(config.NewKeyPath("a"), "value")
+
+	node = root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, node)
+	test.Eq(t, "value", node.Value)
+	test.False(t, node.IsLeaf())
+}
+
+func TestNode_ChildrenOrder_length(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/x"), 1)
+	root.Set(config.NewKeyPath("a/y"), 2)
+	root.Set(config.NewKeyPath("a/z"), 3)
+
+	parentNode := root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, parentNode)
+
+	children := parentNode.Children()
+	must.Eq(t, 3, len(children))
+}
+
+func TestNode_ChildrenOrder_values(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/x"), 1)
+	root.Set(config.NewKeyPath("a/y"), 2)
+	root.Set(config.NewKeyPath("a/z"), 3)
+
+	parentNode := root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, parentNode)
+
+	children := parentNode.Children()
+	test.Eq(t, 1, children[0].Value)
+	test.Eq(t, 2, children[1].Value)
+	test.Eq(t, 3, children[2].Value)
+}
+
+func TestNode_ChildrenOrder_keys(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a/x"), 1)
+	root.Set(config.NewKeyPath("a/y"), 2)
+	root.Set(config.NewKeyPath("a/z"), 3)
+
+	parentNode := root.Get(config.NewKeyPath("a"))
+	must.NotNil(t, parentNode)
+
+	keys := parentNode.ChildrenKeys()
+	test.Eq(t, []string{"x", "y", "z"}, keys)
+}
+
+func TestNode_Children_nil(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	test.Nil(t, node.Children())
+}
+
+func TestNode_Children_initializedButEmpty(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.SetChild("child", tree.New())
+	node.DeleteChild("child")
+	test.Nil(t, node.Children())
+}
+
+func TestNode_ChildrenKeys_nil(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	test.Nil(t, node.ChildrenKeys())
+}
+
+func TestNode_ChildrenKeys_initializedButEmpty(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.SetChild("child", tree.New())
+	node.DeleteChild("child")
+	test.Nil(t, node.ChildrenKeys())
+}
+
+func TestNode_SetChild_ReplacePreservesOrder_order(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+	root.SetChild("b", tree.New())
+	root.SetChild("c", tree.New())
+
+	keys := root.ChildrenKeys()
+	test.Eq(t, []string{"a", "b", "c"}, keys)
+
+	newNode := tree.New()
+
+	newNode.Value = "replaced"
+	root.SetChild("b", newNode)
+
+	keys = root.ChildrenKeys()
+	test.Eq(t, []string{"a", "b", "c"}, keys)
+}
+
+func TestNode_SetChild_ReplacePreservesOrder_value(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+	root.SetChild("b", tree.New())
+	root.SetChild("c", tree.New())
+
+	newNode := tree.New()
+
+	newNode.Value = "replaced"
+	root.SetChild("b", newNode)
+
+	child := root.Child("b")
+	must.NotNil(t, child)
+	test.Eq(t, "replaced", child.Value)
+}
+
+func TestNode_SetChild_nilChild(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", nil)
+
+	child := root.Child("a")
+	test.Nil(t, child)
+}
+
+func TestNode_SetChild_overwriteNil(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+
+	child := root.Child("a")
+	must.NotNil(t, child)
+
+	root.SetChild("a", nil)
+
+	child = root.Child("a")
+	test.Nil(t, child)
+}
+
+func TestNode_DeleteChild_existing(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+	root.SetChild("b", tree.New())
+	root.SetChild("c", tree.New())
+
+	ok := root.DeleteChild("b")
+	test.True(t, ok)
+
+	keys := root.ChildrenKeys()
+	test.Eq(t, []string{"a", "c"}, keys)
+	test.Nil(t, root.Child("b"))
+}
+
+func TestNode_DeleteChild_missing(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.SetChild("a", tree.New())
+	root.SetChild("b", tree.New())
+	root.SetChild("c", tree.New())
+
+	ok := root.DeleteChild("missing")
+	test.False(t, ok)
+}
+
+func TestNode_SourceRevision(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Source = "file"
+	root.Revision = "123"
+
+	root.Set(config.NewKeyPath("a/b"), "value")
+
+	node := root.Get(config.NewKeyPath("a/b"))
+	must.NotNil(t, node)
+	test.Eq(t, "value", node.Value)
+	test.Eq(t, "", node.Source)
+	test.Eq(t, "", node.Revision)
+
+	node.Source = "env"
+	node.Revision = "456"
+	test.Eq(t, "env", node.Source)
+	test.Eq(t, "456", node.Revision)
+}
+
+func TestNode_EmptyPath(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Value = "root value"
+	root.Set(config.KeyPath{}, "new root")
+
+	test.Eq(t, "new root", root.Value)
+}
+
+func TestNode_IntermediateNodesCreated(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("deep/nested/path"), 99)
+
+	deep := root.Get(config.NewKeyPath("deep"))
+	must.NotNil(t, deep)
+	test.False(t, deep.IsLeaf())
+
+	nested := deep.Get(config.NewKeyPath("nested"))
+	must.NotNil(t, nested)
+
+	leaf := root.Get(config.NewKeyPath("deep/nested/path"))
+	must.NotNil(t, leaf)
+	test.Eq(t, 99, leaf.Value)
+}
+
+func TestNode_PathEmptySegment(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(config.NewKeyPath("a//c"), 42)
+
+	node := root.Get(config.NewKeyPath("a//c"))
+	must.NotNil(t, node)
+	test.Eq(t, 42, node.Value)
+
+	emptyNode := root.Get(config.NewKeyPath("a/"))
+	must.NotNil(t, emptyNode)
+	test.False(t, emptyNode.IsLeaf())
+}


### PR DESCRIPTION
internal/tree: added configuration tree node structure.

Added couple of helper modules:
- internal/omap: generic ordered map with insertion order preservation.
- internal/testutil: test helpers for working with iter.Seq and iter.Seq2.

Updated version of golangci-lint to v2.8.0 (from v2.7.2) in Makefile.

Closes TNTP-5712