### PR TITLE
api: implement basic value interface with Get()

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,7 +8,6 @@ env:
   GO_VERSION: 1.25
   CODESPELL_VERSION: v2.4.1
 
-
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -8,16 +8,16 @@ on:
 jobs:
   run-tests:
     if: (github.event_name == 'push') ||
-        (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository) ||
-        (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'workflow_dispatch')
 
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        golang: ['1.24', 'stable']
+        golang: ["1.24", "stable"]
 
     steps:
       - uses: actions/checkout@v4
@@ -33,9 +33,9 @@ jobs:
 
   run-tests-with-coverage:
     if: (github.event_name == 'push') ||
-        (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository) ||
-        (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'workflow_dispatch')
 
     runs-on: ubuntu-latest
 
@@ -48,6 +48,9 @@ jobs:
       - name: run tests, collect code coverage data and send to Coveralls
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use exact Go toolchain version to workaround Go 1.25 covdata issue.
+          # See: https://github.com/golang/go/issues/75031
+          GOTOOLCHAIN: go1.25.0+auto
         run: make coverage coveralls-deps coveralls
 
   run-benchmarks:
@@ -61,5 +64,4 @@ jobs:
         with:
           go-version: ${{ matrix.golang }}
       - name: run benchmarks
-        run:  make bench
-
+        run: make bench

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-coverage.out
+coverage*.out
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,12 +16,18 @@ linters:
   default: all
 
   disable:
-    - dupl     # Dupl is disabled, since we're generating a lot of boilerplate code.
-    - cyclop   # Cyclop is disabled, since cyclomatic complexities is very abstract metric,
-               # that sometimes lead to strange linter behaviour.
-    - wsl      # WSL is disabled, since it's obsolete. Using WSL_v5.
-    - nlreturn # nlreturn is disabled, since it's duplicated by wsl_v5.return check.
-    - ireturn  # ireturn is disabled, since it's not needed.
+    - dupl      # Dupl is disabled, since we're generating a lot of boilerplate code.
+    - cyclop    # Cyclop is disabled, since cyclomatic complexities is very abstract metric,
+                # that sometimes lead to strange linter behaviour.
+    - wsl       # WSL is disabled, since it's obsolete. Using WSL_v5.
+    - nlreturn  # nlreturn is disabled, since it's duplicated by wsl_v5.return check.
+    - ireturn   # ireturn is disabled, since it's not needed.
+    - godox     # godox is disabled to allow TODO comments for unimplemented functionality.
+    - gocognit  # gocognit is disabled, cognitive complexity is too restrictive.
+    - gocyclo   # gocyclo is disabled, cyclomatic complexities is very abstract metric,
+                # that sometimes lead to strange linter behaviour.
+    - funlen    # funlen is disabled, function length limits are too restrictive.
+    - maintidx  # maintidx is disabled, purpose of this metric is unknown.
 
   exclusions:
     generated: lax

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ testrace:
 .PHONY: coverage
 coverage:
 	@echo "Running tests with coveralls"
-	go test -tags "$(TAGS)" $(go list ./... | grep -v test_helpers) -v -p 1 -covermode=atomic -coverprofile=$(COVERAGE_FILE) -count=1
+	go test -tags "$(TAGS)" ./... -v -p 1 -covermode=atomic -coverprofile=$(COVERAGE_FILE) -count=1
 	go tool cover -func=$(COVERAGE_FILE)
 
 .PHONY: coveralls

--- a/collector.go
+++ b/collector.go
@@ -1,0 +1,26 @@
+package config
+
+import "context"
+
+// Collector reads data from a source and streams it as a sequence of values.
+type Collector interface {
+	// Read returns a channel that streams values from the source.
+	// The position of each element (its key) is contained in the Meta information of the Value.
+	// The channel must be closed by the collector after all data has been sent.
+	Read(ctx context.Context) <-chan Value
+
+	// Name returns a human-readable name of the data source for logging and debugging.
+	Name() string
+
+	// Source returns the type of the data source (file, environment variable, etc.).
+	Source() SourceType
+
+	// Revision returns the revision identifier of the configuration.
+	// For sources that do not support versioning, it should return an empty string.
+	Revision() RevisionType
+
+	// KeepOrder returns true if the order of keys must be preserved.
+	// When true, the collector is considered as the "source of truth" for key order
+	// at the corresponding nesting level during merging.
+	KeepOrder() bool
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,10 @@
+package config
+
+import "errors"
+
+var (
+	// ErrKeyNotFound is returned when a configuration key is not found.
+	ErrKeyNotFound = errors.New("key not found")
+	// ErrPathNotFound is returned when a configuration path is not found.
+	ErrPathNotFound = errors.New("path not found")
+)

--- a/internal/omap/orderedmap_test.go
+++ b/internal/omap/orderedmap_test.go
@@ -416,3 +416,24 @@ func TestOrderedMap_EmptyMapBehavior_DeleteMissing(t *testing.T) {
 	m := omap.New[string, int]()
 	test.False(t, m.Delete("anything"))
 }
+
+func TestOrderedMap_EmptyMapBehavior_Keys(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeqEmpty(t, m.Keys())
+}
+
+func TestOrderedMap_EmptyMapBehavior_Values(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeqEmpty(t, m.Values())
+}
+
+func TestOrderedMap_EmptyMapBehavior_Items(t *testing.T) {
+	t.Parallel()
+
+	m := omap.New[string, int]()
+	testutil.TestIterSeq2Empty(t, m.Items())
+}

--- a/internal/tree/doc.go
+++ b/internal/tree/doc.go
@@ -1,0 +1,2 @@
+// Package tree provides an in-memory configuration tree.
+package tree

--- a/internal/tree/errors.go
+++ b/internal/tree/errors.go
@@ -1,0 +1,38 @@
+package tree
+
+import "errors"
+
+var (
+	// ErrDestinationMustBePointer is returned when destination is not a non-nil pointer.
+	ErrDestinationMustBePointer = errors.New("destination must be a non-nil pointer")
+	// ErrUnsupportedDestinationType is returned when destination type is unsupported.
+	ErrUnsupportedDestinationType = errors.New("unsupported destination type")
+	// ErrParseDuration is returned when a duration string cannot be parsed.
+	ErrParseDuration = errors.New("cannot parse duration from string")
+	// ErrConvertToDuration is returned when a value cannot be converted to time.Duration.
+	ErrConvertToDuration = errors.New("cannot convert to time.Duration")
+	// ErrConvertToBool is returned when a value cannot be converted to bool.
+	ErrConvertToBool = errors.New("cannot convert to bool")
+	// ErrConvertToInt is returned when a value cannot be converted to int.
+	ErrConvertToInt = errors.New("cannot convert to int")
+	// ErrOverflow is returned when a value overflows the destination type.
+	ErrOverflow = errors.New("overflow")
+	// ErrNegativeToUnsigned is returned when a negative value cannot be converted to unsigned.
+	ErrNegativeToUnsigned = errors.New("cannot convert negative value to unsigned")
+	// ErrConvertToUint is returned when a value cannot be converted to uint.
+	ErrConvertToUint = errors.New("cannot convert to uint")
+	// ErrConvertToFloat is returned when a value cannot be converted to float.
+	ErrConvertToFloat = errors.New("cannot convert to float")
+	// ErrSourceNotSliceOrArray is returned when source is not a slice or array.
+	ErrSourceNotSliceOrArray = errors.New("source is not a slice or array")
+	// ErrSourceNotMap is returned when source is not a map.
+	ErrSourceNotMap = errors.New("source is not a map")
+	// ErrDestinationMapStringKeys is returned when destination map does not have string keys.
+	ErrDestinationMapStringKeys = errors.New("destination map must have string keys")
+	// ErrSourceMapKeyNotString is returned when source map key is not string.
+	ErrSourceMapKeyNotString = errors.New("source map key is not string")
+	// ErrSourceForStructMustBeMap is returned when source for struct is not a map.
+	ErrSourceForStructMustBeMap = errors.New("source for struct must be a map")
+	// ErrSourceMapMustHaveStringKeys is returned when source map does not have string keys.
+	ErrSourceMapMustHaveStringKeys = errors.New("source map must have string keys")
+)

--- a/internal/tree/node.go
+++ b/internal/tree/node.go
@@ -1,11 +1,10 @@
-// Package tree provides an in-memory configuration tree with ordered children.
 package tree
 
 import (
 	"slices"
 
-	"github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/internal/omap"
+	"github.com/tarantool/go-config/path"
 )
 
 // Value represents a configuration value.
@@ -99,7 +98,7 @@ func (n *Node) DeleteChild(key string) bool {
 }
 
 // Set sets the value at the given path, creating intermediate nodes as needed.
-func (n *Node) Set(path config.KeyPath, value Value) {
+func (n *Node) Set(path path.KeyPath, value Value) {
 	if len(path) == 0 {
 		n.Value = value
 		return
@@ -117,7 +116,7 @@ func (n *Node) Set(path config.KeyPath, value Value) {
 }
 
 // Get returns the node at the given path, or nil if not found.
-func (n *Node) Get(path config.KeyPath) *Node {
+func (n *Node) Get(path path.KeyPath) *Node {
 	if len(path) == 0 {
 		return n
 	}
@@ -133,7 +132,7 @@ func (n *Node) Get(path config.KeyPath) *Node {
 }
 
 // GetValue returns the value at the given path, or nil if not found or node is not a leaf.
-func (n *Node) GetValue(path config.KeyPath) Value {
+func (n *Node) GetValue(path path.KeyPath) Value {
 	node := n.Get(path)
 	if node == nil || !node.IsLeaf() {
 		return nil

--- a/internal/tree/node_test.go
+++ b/internal/tree/node_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 
-	"github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/internal/tree"
+	"github.com/tarantool/go-config/path"
 )
 
 func TestNode_Set_Get_leaf(t *testing.T) {
@@ -15,20 +15,20 @@ func TestNode_Set_Get_leaf(t *testing.T) {
 
 	root := tree.New()
 
-	root.Set(config.NewKeyPath("a/b/c"), 42)
-	root.Set(config.NewKeyPath("a/b/d"), "hello")
-	root.Set(config.NewKeyPath("x/y"), true)
+	root.Set(path.NewKeyPath("a/b/c"), 42)
+	root.Set(path.NewKeyPath("a/b/d"), "hello")
+	root.Set(path.NewKeyPath("x/y"), true)
 
-	node := root.Get(config.NewKeyPath("a/b/c"))
+	node := root.Get(path.NewKeyPath("a/b/c"))
 	must.NotNil(t, node)
 	test.True(t, node.IsLeaf())
 	test.Eq(t, 42, node.Value)
 
-	node = root.Get(config.NewKeyPath("a/b/d"))
+	node = root.Get(path.NewKeyPath("a/b/d"))
 	must.NotNil(t, node)
 	test.Eq(t, "hello", node.Value)
 
-	node = root.Get(config.NewKeyPath("x/y"))
+	node = root.Get(path.NewKeyPath("x/y"))
 	must.NotNil(t, node)
 	test.Eq(t, true, node.Value)
 }
@@ -38,11 +38,11 @@ func TestNode_Set_Get_nonLeaf(t *testing.T) {
 
 	root := tree.New()
 
-	root.Set(config.NewKeyPath("a/b/c"), 42)
-	root.Set(config.NewKeyPath("a/b/d"), "hello")
-	root.Set(config.NewKeyPath("x/y"), true)
+	root.Set(path.NewKeyPath("a/b/c"), 42)
+	root.Set(path.NewKeyPath("a/b/d"), "hello")
+	root.Set(path.NewKeyPath("x/y"), true)
 
-	node := root.Get(config.NewKeyPath("a/b"))
+	node := root.Get(path.NewKeyPath("a/b"))
 	must.NotNil(t, node)
 	test.False(t, node.IsLeaf())
 }
@@ -52,11 +52,11 @@ func TestNode_Set_Get_missing(t *testing.T) {
 
 	root := tree.New()
 
-	root.Set(config.NewKeyPath("a/b/c"), 42)
-	root.Set(config.NewKeyPath("a/b/d"), "hello")
-	root.Set(config.NewKeyPath("x/y"), true)
+	root.Set(path.NewKeyPath("a/b/c"), 42)
+	root.Set(path.NewKeyPath("a/b/d"), "hello")
+	root.Set(path.NewKeyPath("x/y"), true)
 
-	node := root.Get(config.NewKeyPath("nonexistent"))
+	node := root.Get(path.NewKeyPath("nonexistent"))
 	test.Nil(t, node)
 }
 
@@ -67,7 +67,7 @@ func TestNode_Get_emptyPath(t *testing.T) {
 
 	root.Value = "test value"
 
-	node := root.Get(config.KeyPath{})
+	node := root.Get(path.KeyPath{})
 	must.NotNil(t, node)
 	test.Eq(t, "test value", node.Value)
 }
@@ -150,9 +150,9 @@ func TestNode_GetValue_leaf(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/b"), 100)
+	root.Set(path.NewKeyPath("a/b"), 100)
 
-	val := root.GetValue(config.NewKeyPath("a/b"))
+	val := root.GetValue(path.NewKeyPath("a/b"))
 	test.Eq(t, 100, val)
 }
 
@@ -160,9 +160,9 @@ func TestNode_GetValue_nonLeaf(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/b"), 100)
+	root.Set(path.NewKeyPath("a/b"), 100)
 
-	val := root.GetValue(config.NewKeyPath("a"))
+	val := root.GetValue(path.NewKeyPath("a"))
 	test.Nil(t, val)
 }
 
@@ -170,9 +170,9 @@ func TestNode_GetValue_missing(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/b"), 100)
+	root.Set(path.NewKeyPath("a/b"), 100)
 
-	val := root.GetValue(config.NewKeyPath("missing"))
+	val := root.GetValue(path.NewKeyPath("missing"))
 	test.Nil(t, val)
 }
 
@@ -180,10 +180,10 @@ func TestNode_Set_Overwrite(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/b"), "first")
-	root.Set(config.NewKeyPath("a/b"), "second")
+	root.Set(path.NewKeyPath("a/b"), "first")
+	root.Set(path.NewKeyPath("a/b"), "second")
 
-	node := root.Get(config.NewKeyPath("a/b"))
+	node := root.Get(path.NewKeyPath("a/b"))
 	must.NotNil(t, node)
 	test.Eq(t, "second", node.Value)
 }
@@ -192,16 +192,16 @@ func TestNode_Set_overwriteLeafToNonLeaf(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a"), "value")
+	root.Set(path.NewKeyPath("a"), "value")
 
-	node := root.Get(config.NewKeyPath("a"))
+	node := root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, node)
 	test.Eq(t, "value", node.Value)
 	test.True(t, node.IsLeaf())
 
 	node.SetChild("b", tree.New())
 
-	node = root.Get(config.NewKeyPath("a"))
+	node = root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, node)
 	test.Eq(t, "value", node.Value)
 	test.False(t, node.IsLeaf())
@@ -216,13 +216,13 @@ func TestNode_Set_overwriteNonLeafToLeaf(t *testing.T) {
 	nodeA := root.Child("a")
 	nodeA.SetChild("b", tree.New())
 
-	node := root.Get(config.NewKeyPath("a"))
+	node := root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, node)
 	test.False(t, node.IsLeaf())
 
-	root.Set(config.NewKeyPath("a"), "value")
+	root.Set(path.NewKeyPath("a"), "value")
 
-	node = root.Get(config.NewKeyPath("a"))
+	node = root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, node)
 	test.Eq(t, "value", node.Value)
 	test.False(t, node.IsLeaf())
@@ -232,11 +232,11 @@ func TestNode_ChildrenOrder_length(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/x"), 1)
-	root.Set(config.NewKeyPath("a/y"), 2)
-	root.Set(config.NewKeyPath("a/z"), 3)
+	root.Set(path.NewKeyPath("a/x"), 1)
+	root.Set(path.NewKeyPath("a/y"), 2)
+	root.Set(path.NewKeyPath("a/z"), 3)
 
-	parentNode := root.Get(config.NewKeyPath("a"))
+	parentNode := root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, parentNode)
 
 	children := parentNode.Children()
@@ -247,11 +247,11 @@ func TestNode_ChildrenOrder_values(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/x"), 1)
-	root.Set(config.NewKeyPath("a/y"), 2)
-	root.Set(config.NewKeyPath("a/z"), 3)
+	root.Set(path.NewKeyPath("a/x"), 1)
+	root.Set(path.NewKeyPath("a/y"), 2)
+	root.Set(path.NewKeyPath("a/z"), 3)
 
-	parentNode := root.Get(config.NewKeyPath("a"))
+	parentNode := root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, parentNode)
 
 	children := parentNode.Children()
@@ -264,11 +264,11 @@ func TestNode_ChildrenOrder_keys(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a/x"), 1)
-	root.Set(config.NewKeyPath("a/y"), 2)
-	root.Set(config.NewKeyPath("a/z"), 3)
+	root.Set(path.NewKeyPath("a/x"), 1)
+	root.Set(path.NewKeyPath("a/y"), 2)
+	root.Set(path.NewKeyPath("a/z"), 3)
 
-	parentNode := root.Get(config.NewKeyPath("a"))
+	parentNode := root.Get(path.NewKeyPath("a"))
 	must.NotNil(t, parentNode)
 
 	keys := parentNode.ChildrenKeys()
@@ -398,6 +398,15 @@ func TestNode_DeleteChild_missing(t *testing.T) {
 	test.False(t, ok)
 }
 
+func TestNode_DeleteChild_NilChildren(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	// root.children is nil initially.
+	ok := root.DeleteChild("any")
+	test.False(t, ok)
+}
+
 func TestNode_SourceRevision(t *testing.T) {
 	t.Parallel()
 
@@ -406,9 +415,9 @@ func TestNode_SourceRevision(t *testing.T) {
 	root.Source = "file"
 	root.Revision = "123"
 
-	root.Set(config.NewKeyPath("a/b"), "value")
+	root.Set(path.NewKeyPath("a/b"), "value")
 
-	node := root.Get(config.NewKeyPath("a/b"))
+	node := root.Get(path.NewKeyPath("a/b"))
 	must.NotNil(t, node)
 	test.Eq(t, "value", node.Value)
 	test.Eq(t, "", node.Source)
@@ -426,7 +435,7 @@ func TestNode_EmptyPath(t *testing.T) {
 	root := tree.New()
 
 	root.Value = "root value"
-	root.Set(config.KeyPath{}, "new root")
+	root.Set(path.KeyPath{}, "new root")
 
 	test.Eq(t, "new root", root.Value)
 }
@@ -435,16 +444,16 @@ func TestNode_IntermediateNodesCreated(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("deep/nested/path"), 99)
+	root.Set(path.NewKeyPath("deep/nested/path"), 99)
 
-	deep := root.Get(config.NewKeyPath("deep"))
+	deep := root.Get(path.NewKeyPath("deep"))
 	must.NotNil(t, deep)
 	test.False(t, deep.IsLeaf())
 
-	nested := deep.Get(config.NewKeyPath("nested"))
+	nested := deep.Get(path.NewKeyPath("nested"))
 	must.NotNil(t, nested)
 
-	leaf := root.Get(config.NewKeyPath("deep/nested/path"))
+	leaf := root.Get(path.NewKeyPath("deep/nested/path"))
 	must.NotNil(t, leaf)
 	test.Eq(t, 99, leaf.Value)
 }
@@ -453,13 +462,13 @@ func TestNode_PathEmptySegment(t *testing.T) {
 	t.Parallel()
 
 	root := tree.New()
-	root.Set(config.NewKeyPath("a//c"), 42)
+	root.Set(path.NewKeyPath("a//c"), 42)
 
-	node := root.Get(config.NewKeyPath("a//c"))
+	node := root.Get(path.NewKeyPath("a//c"))
 	must.NotNil(t, node)
 	test.Eq(t, 42, node.Value)
 
-	emptyNode := root.Get(config.NewKeyPath("a/"))
+	emptyNode := root.Get(path.NewKeyPath("a/"))
 	must.NotNil(t, emptyNode)
 	test.False(t, emptyNode.IsLeaf())
 }

--- a/internal/tree/value.go
+++ b/internal/tree/value.go
@@ -1,0 +1,598 @@
+package tree
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/path"
+	"github.com/tarantool/go-config/value"
+)
+
+// valueImpl is the internal implementation of the value.Value interface.
+type valueImpl struct {
+	node    *Node
+	keyPath path.KeyPath
+	source  meta.SourceInfo
+	rev     meta.RevisionType
+}
+
+// NewValue creates a new value.Value from a tree node and its key path.
+// The source information and revision are extracted from the node.
+func NewValue(node *Node, keyPath path.KeyPath) value.Value {
+	var source meta.SourceInfo
+	if node.Source != "" {
+		source = meta.SourceInfo{
+			Name: node.Source,
+			Type: meta.UnknownSource,
+		}
+	}
+
+	rev := meta.RevisionType(node.Revision)
+
+	return &valueImpl{
+		node:    node,
+		keyPath: keyPath,
+		source:  source,
+		rev:     rev,
+	}
+}
+
+// Get implements value.Value.Get.
+func (v *valueImpl) Get(dest any) error {
+	// Ensure dest is a pointer.
+	destVal := reflect.ValueOf(dest)
+	if destVal.Kind() != reflect.Ptr || destVal.IsNil() {
+		return ErrDestinationMustBePointer
+	}
+	// Convert the node to a generic value.
+	raw := nodeToValue(v.node)
+	// Decode raw into dest using reflection.
+	return decode(raw, destVal.Elem())
+}
+
+// Meta implements value.Value.Meta.
+func (v *valueImpl) Meta() meta.Info {
+	return meta.Info{
+		Key:      v.keyPath,
+		Source:   v.source,
+		Revision: v.rev,
+	}
+}
+
+// nodeToValue converts a tree node into a generic Go value.
+// If the node is a leaf (no children), returns node.Value (which may be a slice, map, or primitive).
+// Otherwise, builds a map[string]any from its children.
+func nodeToValue(node *Node) any {
+	if node.IsLeaf() {
+		return node.Value
+	}
+	// Build map from children.
+	children := node.Children()
+	keys := node.ChildrenKeys()
+
+	m := make(map[string]any, len(children))
+	for i, child := range children {
+		m[keys[i]] = nodeToValue(child)
+	}
+
+	return m
+}
+
+// decode decodes a generic value into a reflect.Value destination.
+func decode(src any, dst reflect.Value) error {
+	// Handle nil source.
+	if src == nil {
+		// Set zero value.
+		dst.Set(reflect.Zero(dst.Type()))
+		return nil
+	}
+	// Convert source to reflect.Value.
+	srcVal := reflect.ValueOf(src)
+	// If types are directly assignable, assign.
+	if srcVal.Type().AssignableTo(dst.Type()) {
+		dst.Set(srcVal)
+		return nil
+	}
+	// Check for time.Duration special case.
+	if dst.Type() == reflect.TypeFor[time.Duration]() {
+		return decodeDuration(src, dst)
+	}
+	// Perform type conversion based on destination kind.
+	switch dst.Kind() {
+	case reflect.Bool:
+		return decodeBool(src, dst)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return decodeInt(src, dst)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return decodeUint(src, dst)
+	case reflect.Float32, reflect.Float64:
+		return decodeFloat(src, dst)
+	case reflect.String:
+		return decodeString(src, dst)
+	case reflect.Slice:
+		return decodeSlice(src, dst)
+	case reflect.Map:
+		return decodeMap(src, dst)
+	case reflect.Struct:
+		return decodeStruct(src, dst)
+	case reflect.Ptr:
+		return decodePtr(src, dst)
+	case reflect.Interface:
+		// Assign directly if src type implements the interface.
+		if srcVal.Type().Implements(dst.Type()) {
+			dst.Set(srcVal)
+			return nil
+		}
+		// Otherwise, set as empty interface.
+		dst.Set(srcVal)
+
+		return nil
+	case reflect.Invalid, reflect.Uintptr, reflect.Complex64,
+		reflect.Complex128, reflect.Array, reflect.Chan,
+		reflect.Func, reflect.UnsafePointer:
+		// These kinds are unsupported.
+		return fmt.Errorf("%w: %v", ErrUnsupportedDestinationType, dst.Kind())
+	default:
+		return fmt.Errorf("%w: %v", ErrUnsupportedDestinationType, dst.Kind())
+	}
+}
+
+const (
+	maxUint64SafeSeconds = uint64(math.MaxInt64 / int64(time.Second))
+	maxInt64SafeSeconds  = math.MaxInt64 / int64(time.Second)
+)
+
+func safeConvertUintToSecDuration(uintSeconds uint64) (time.Duration, error) {
+	// Check if uintSeconds seconds would overflow when converted to nanoseconds (Duration).
+	if uintSeconds > maxUint64SafeSeconds {
+		return 0, fmt.Errorf("%w: %d", ErrOverflow, uintSeconds)
+	}
+
+	return time.Duration(uintSeconds) * time.Second, nil
+}
+
+func safeConvertIntToSecDuration(intSeconds int64) (time.Duration, error) {
+	// Check if intSeconds seconds would overflow when converted to nanoseconds (Duration).
+	if intSeconds > maxInt64SafeSeconds {
+		return 0, fmt.Errorf("%w: %d", ErrOverflow, intSeconds)
+	}
+
+	return time.Duration(intSeconds) * time.Second, nil
+}
+
+// decodeDuration converts src to time.Duration.
+func decodeDuration(src any, dst reflect.Value) error {
+	switch typedSrc := src.(type) {
+	case string:
+		d, err := time.ParseDuration(typedSrc)
+		if err != nil {
+			return fmt.Errorf("%w %q: %w", ErrParseDuration, typedSrc, err)
+		}
+
+		dst.Set(reflect.ValueOf(d))
+
+		return nil
+	case int, int8, int16, int32, int64:
+		// Treat as seconds, convert to nanoseconds.
+		val := reflect.ValueOf(typedSrc).Int()
+
+		ns, err := safeConvertIntToSecDuration(val)
+		if err != nil {
+			return err
+		}
+
+		dst.Set(reflect.ValueOf(ns))
+
+		return nil
+	case uint, uint8, uint16, uint32, uint64:
+		// Treat as seconds, convert to nanoseconds.
+		val := reflect.ValueOf(typedSrc).Uint()
+
+		ns, err := safeConvertUintToSecDuration(val)
+		if err != nil {
+			return err
+		}
+
+		dst.Set(reflect.ValueOf(ns))
+
+		return nil
+	case float32, float64:
+		// Treat as seconds, convert to nanoseconds.
+		val := reflect.ValueOf(typedSrc).Float()
+		ns := time.Duration(val * float64(time.Second))
+		dst.Set(reflect.ValueOf(ns))
+
+		return nil
+	default:
+		return fmt.Errorf("%w: %T", ErrConvertToDuration, src)
+	}
+}
+
+// decodeBool converts src to bool.
+func decodeBool(src any, dst reflect.Value) error {
+	switch typedSrc := src.(type) {
+	case bool:
+		dst.SetBool(typedSrc)
+		return nil
+	case string:
+		b, err := strconv.ParseBool(typedSrc)
+		if err != nil {
+			return fmt.Errorf("%w %q: %w", ErrConvertToBool, typedSrc, err)
+		}
+
+		dst.SetBool(b)
+
+		return nil
+	case int, int8, int16, int32, int64:
+		// Treat non-zero as true.
+		dst.SetBool(reflect.ValueOf(typedSrc).Int() != 0)
+		return nil
+	case uint, uint8, uint16, uint32, uint64:
+		// Treat non-zero as true.
+		dst.SetBool(reflect.ValueOf(typedSrc).Uint() != 0)
+		return nil
+	default:
+		return fmt.Errorf("%w: %T", ErrConvertToBool, src)
+	}
+}
+
+func safeUintToInt64(u uint) (int64, error) {
+	if uint64(u) > math.MaxInt64 {
+		return 0, fmt.Errorf("%w: %d", ErrOverflow, u)
+	}
+
+	return int64(u), nil //nolint:gosec // conversion is safe due to the check above.
+}
+
+func safeUint64ToInt64(uk uint64) (int64, error) {
+	if uk > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("%w: %d", ErrOverflow, uk)
+	}
+
+	return int64(uk), nil
+}
+
+// decodeInt converts src to signed integer.
+func decodeInt(src any, dst reflect.Value) error {
+	var result int64
+
+	switch typedSrc := src.(type) {
+	case int:
+		result = int64(typedSrc)
+	case int8:
+		result = int64(typedSrc)
+	case int16:
+		result = int64(typedSrc)
+	case int32:
+		result = int64(typedSrc)
+	case int64:
+		result = typedSrc
+	case uint:
+		var err error
+
+		result, err = safeUintToInt64(typedSrc)
+		if err != nil {
+			return err
+		}
+	case uint8:
+		result = int64(typedSrc)
+	case uint16:
+		result = int64(typedSrc)
+	case uint32:
+		result = int64(typedSrc)
+	case uint64:
+		var err error
+
+		result, err = safeUint64ToInt64(typedSrc)
+		if err != nil {
+			return err
+		}
+	case float32:
+		result = int64(typedSrc)
+	case float64:
+		result = int64(typedSrc)
+	case string:
+		i, err := strconv.ParseInt(typedSrc, 10, 64)
+		if err != nil {
+			return fmt.Errorf("%w %q: %w", ErrConvertToInt, typedSrc, err)
+		}
+
+		result = i
+	case bool:
+		if typedSrc {
+			result = 1
+		} else {
+			result = 0
+		}
+	default:
+		return fmt.Errorf("%w: %T", ErrConvertToInt, src)
+	}
+	// Check for overflow of the specific destination type.
+	switch dst.Kind() {
+	case reflect.Int8:
+		if result < -1<<7 || result >= 1<<7 {
+			return fmt.Errorf("%w int8: %d", ErrOverflow, result)
+		}
+	case reflect.Int16:
+		if result < -1<<15 || result >= 1<<15 {
+			return fmt.Errorf("%w int16: %d", ErrOverflow, result)
+		}
+	case reflect.Int32:
+		if result < -1<<31 || result >= 1<<31 {
+			return fmt.Errorf("%w int32: %d", ErrOverflow, result)
+		}
+	case reflect.Int64:
+		// No overflow check needed.
+	case reflect.Int:
+		// Platform dependent; assume int64.
+	case reflect.Invalid, reflect.Bool, reflect.Uint, reflect.Uint8,
+		reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64,
+		reflect.Complex128, reflect.Array, reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice,
+		reflect.String, reflect.Struct, reflect.UnsafePointer:
+		// Unreachable because decodeInt is only called for signed integer kinds.
+	}
+
+	dst.SetInt(result)
+
+	return nil
+}
+
+// decodeUint converts src to unsigned integer.
+func decodeUint(src any, dst reflect.Value) error {
+	var result uint64
+
+	switch typedSrcValue := src.(type) {
+	case uint:
+		result = uint64(typedSrcValue)
+	case uint8:
+		result = uint64(typedSrcValue)
+	case uint16:
+		result = uint64(typedSrcValue)
+	case uint32:
+		result = uint64(typedSrcValue)
+	case uint64:
+		result = typedSrcValue
+	case int, int8, int16, int32, int64:
+		val := reflect.ValueOf(typedSrcValue).Int()
+		if val < 0 {
+			return fmt.Errorf("%w: %d", ErrNegativeToUnsigned, val)
+		}
+
+		result = uint64(val)
+	case float32:
+		if typedSrcValue < 0 {
+			return fmt.Errorf("%w: %v", ErrNegativeToUnsigned, typedSrcValue)
+		}
+
+		result = uint64(typedSrcValue)
+	case float64:
+		if typedSrcValue < 0 {
+			return fmt.Errorf("%w: %v", ErrNegativeToUnsigned, typedSrcValue)
+		}
+
+		result = uint64(typedSrcValue)
+	case string:
+		u, err := strconv.ParseUint(typedSrcValue, 10, 64)
+		if err != nil {
+			return fmt.Errorf("%w %q: %w", ErrConvertToUint, typedSrcValue, err)
+		}
+
+		result = u
+	case bool:
+		if typedSrcValue {
+			result = 1
+		} else {
+			result = 0
+		}
+	default:
+		return fmt.Errorf("%w: %T", ErrConvertToUint, src)
+	}
+	// Overflow check.
+	switch dst.Kind() {
+	case reflect.Uint8:
+		if result >= 1<<8 {
+			return fmt.Errorf("%w uint8: %d", ErrOverflow, result)
+		}
+	case reflect.Uint16:
+		if result >= 1<<16 {
+			return fmt.Errorf("%w uint16: %d", ErrOverflow, result)
+		}
+	case reflect.Uint32:
+		if result >= 1<<32 {
+			return fmt.Errorf("%w uint32: %d", ErrOverflow, result)
+		}
+	case reflect.Uint64:
+		// No overflow check needed.
+	case reflect.Uint:
+		// Platform dependent; assume 64-bit.
+	case reflect.Invalid, reflect.Bool, reflect.Int, reflect.Int8,
+		reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64,
+		reflect.Complex128, reflect.Array, reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice,
+		reflect.String, reflect.Struct, reflect.UnsafePointer:
+		// Unreachable because decodeUint is only called for unsigned integer kinds.
+	}
+
+	dst.SetUint(result)
+
+	return nil
+}
+
+// decodeFloat converts src to float.
+func decodeFloat(src any, dst reflect.Value) error {
+	var result float64
+
+	switch typedSrcValue := src.(type) {
+	case float32:
+		result = float64(typedSrcValue)
+	case float64:
+		result = typedSrcValue
+	case int, int8, int16, int32, int64:
+		result = float64(reflect.ValueOf(typedSrcValue).Int())
+	case uint, uint8, uint16, uint32, uint64:
+		result = float64(reflect.ValueOf(typedSrcValue).Uint())
+	case string:
+		f, err := strconv.ParseFloat(typedSrcValue, 64)
+		if err != nil {
+			return fmt.Errorf("%w %q: %w", ErrConvertToFloat, typedSrcValue, err)
+		}
+
+		result = f
+	default:
+		return fmt.Errorf("%w: %T", ErrConvertToFloat, src)
+	}
+	// Overflow check for float32.
+	if dst.Kind() == reflect.Float32 {
+		// Naive overflow check; not exhaustive.
+		if result > 3.4e38 || result < -3.4e38 {
+			return fmt.Errorf("%w float32: %g", ErrOverflow, result)
+		}
+	}
+
+	dst.SetFloat(result)
+
+	return nil
+}
+
+// decodeString converts src to string.
+func decodeString(src any, dst reflect.Value) error {
+	switch typedSrcValue := src.(type) {
+	case string:
+		dst.SetString(typedSrcValue)
+	case []byte:
+		dst.SetString(string(typedSrcValue))
+	case fmt.Stringer:
+		dst.SetString(typedSrcValue.String())
+	default:
+		// Use fmt.Sprint as fallback.
+		dst.SetString(fmt.Sprint(typedSrcValue))
+	}
+
+	return nil
+}
+
+// decodeSlice converts src to slice.
+func decodeSlice(src any, dst reflect.Value) error {
+	srcVal := reflect.ValueOf(src)
+	if srcVal.Kind() != reflect.Slice && srcVal.Kind() != reflect.Array {
+		return fmt.Errorf("%w: %T", ErrSourceNotSliceOrArray, src)
+	}
+
+	length := srcVal.Len()
+
+	slice := reflect.MakeSlice(dst.Type(), length, length)
+	for i := range length {
+		elem := srcVal.Index(i).Interface()
+
+		err := decode(elem, slice.Index(i))
+		if err != nil {
+			return fmt.Errorf("slice element [%d]: %w", i, err)
+		}
+	}
+
+	dst.Set(slice)
+
+	return nil
+}
+
+// decodeMap converts src to map.
+func decodeMap(src any, dst reflect.Value) error {
+	srcVal := reflect.ValueOf(src)
+	if srcVal.Kind() != reflect.Map {
+		return fmt.Errorf("%w: %T", ErrSourceNotMap, src)
+	}
+	// Destination map must have string keys (as per configuration keys).
+	if dst.Type().Key().Kind() != reflect.String {
+		return fmt.Errorf("%w: %v", ErrDestinationMapStringKeys, dst.Type().Key())
+	}
+	// Create a new map.
+	mapType := dst.Type()
+	newMap := reflect.MakeMapWithSize(mapType, srcVal.Len())
+
+	iter := srcVal.MapRange()
+	for iter.Next() {
+		key := iter.Key()
+		if key.Kind() != reflect.String {
+			return fmt.Errorf("%w: %v", ErrSourceMapKeyNotString, key.Kind())
+		}
+		// Create a new value of the map's element type.
+		elem := reflect.New(mapType.Elem()).Elem()
+
+		err := decode(iter.Value().Interface(), elem)
+		if err != nil {
+			return fmt.Errorf("map key %q: %w", key.String(), err)
+		}
+
+		newMap.SetMapIndex(key, elem)
+	}
+
+	dst.Set(newMap)
+
+	return nil
+}
+
+// decodeStruct converts src to struct.
+func decodeStruct(src any, dst reflect.Value) error {
+	srcVal := reflect.ValueOf(src)
+	// Source must be a map[string]any.
+	if srcVal.Kind() != reflect.Map {
+		return fmt.Errorf("%w: %T", ErrSourceForStructMustBeMap, src)
+	}
+
+	if srcVal.Type().Key().Kind() != reflect.String {
+		return ErrSourceMapMustHaveStringKeys
+	}
+	// Iterate over struct fields.
+	dstType := dst.Type()
+	for i := range dstType.NumField() {
+		field := dstType.Field(i)
+		// Skip unexported fields.
+		if !field.IsExported() {
+			continue
+		}
+		// Get yaml tag.
+		tag := field.Tag.Get("yaml")
+		if tag == "" {
+			// Fallback to field name.
+			tag = field.Name
+		} else {
+			// Handle yaml tag options like "omitempty".
+			if comma := strings.Index(tag, ","); comma != -1 {
+				tag = tag[:comma]
+			}
+		}
+		// Look up key in source map.
+		key := reflect.ValueOf(tag)
+
+		val := srcVal.MapIndex(key)
+		if !val.IsValid() {
+			// Field not found; leave zero value.
+			continue
+		}
+		// Decode into field.
+		err := decode(val.Interface(), dst.Field(i))
+		if err != nil {
+			return fmt.Errorf("field %q: %w", field.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// decodePtr converts src to pointer.
+func decodePtr(src any, dst reflect.Value) error {
+	// If dst is nil, allocate a new value.
+	if dst.IsNil() {
+		dst.Set(reflect.New(dst.Type().Elem()))
+	}
+	// Dereference and decode.
+	return decode(src, dst.Elem())
+}

--- a/internal/tree/value_test.go
+++ b/internal/tree/value_test.go
@@ -1,0 +1,1716 @@
+package tree_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+
+	"github.com/tarantool/go-config/internal/tree"
+	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/path"
+)
+
+var _ = math.MaxInt64
+
+type testStringer struct{}
+
+func (testStringer) String() string { return "I am a Stringer" }
+
+func TestValue_Get_Int(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("int"), 42)
+
+	node := root.Get(path.NewKeyPath("int"))
+	must.NotNil(t, node)
+
+	val := tree.NewValue(node, path.NewKeyPath("int"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 42, i)
+}
+
+func TestValue_Get_IntToStringConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("int"), 42)
+
+	node := root.Get(path.NewKeyPath("int"))
+	must.NotNil(t, node)
+
+	val := tree.NewValue(node, path.NewKeyPath("int"))
+
+	var s string
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "42", s)
+}
+
+func TestValue_Get_String(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("str"), "hello")
+
+	node := root.Get(path.NewKeyPath("str"))
+	must.NotNil(t, node)
+
+	val := tree.NewValue(node, path.NewKeyPath("str"))
+
+	var str string
+
+	err := val.Get(&str)
+	must.NoError(t, err)
+	test.Eq(t, "hello", str)
+}
+
+func TestValue_Get_Bool(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("bool"), true)
+
+	node := root.Get(path.NewKeyPath("bool"))
+	must.NotNil(t, node)
+
+	val := tree.NewValue(node, path.NewKeyPath("bool"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.True(t, b)
+}
+
+func TestValue_Get_Float(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("float"), 3.14)
+
+	node := root.Get(path.NewKeyPath("float"))
+	must.NotNil(t, node)
+
+	val := tree.NewValue(node, path.NewKeyPath("float"))
+
+	var f float64
+
+	err := val.Get(&f)
+	must.NoError(t, err)
+	test.Eq(t, 3.14, f)
+}
+
+func TestValue_Get_BoolFromString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("boolstr"), "true")
+
+	node := root.Get(path.NewKeyPath("boolstr"))
+	val := tree.NewValue(node, path.NewKeyPath("boolstr"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.True(t, b)
+}
+
+func TestValue_Get_BoolFromBool(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("booltrue"), true)
+
+	node := root.Get(path.NewKeyPath("booltrue"))
+	val := tree.NewValue(node, path.NewKeyPath("booltrue"))
+
+	var got bool
+
+	err := val.Get(&got)
+	must.NoError(t, err)
+	test.True(t, got)
+
+	root.Set(path.NewKeyPath("boolfalse"), false)
+
+	node = root.Get(path.NewKeyPath("boolfalse"))
+	val = tree.NewValue(node, path.NewKeyPath("boolfalse"))
+
+	err = val.Get(&got)
+	must.NoError(t, err)
+	test.False(t, got)
+}
+
+func TestValue_Get_IntFromString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("intstr"), "123")
+
+	node := root.Get(path.NewKeyPath("intstr"))
+	val := tree.NewValue(node, path.NewKeyPath("intstr"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 123, i)
+}
+
+func TestValue_Get_FloatFromString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("floatstr"), "45.6")
+
+	node := root.Get(path.NewKeyPath("floatstr"))
+	val := tree.NewValue(node, path.NewKeyPath("floatstr"))
+
+	var f float64
+
+	err := val.Get(&f)
+	must.NoError(t, err)
+	test.Eq(t, 45.6, f)
+}
+
+func TestValue_Get_DurationFromString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("duration"), "5s")
+
+	node := root.Get(path.NewKeyPath("duration"))
+	val := tree.NewValue(node, path.NewKeyPath("duration"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.NoError(t, err)
+	test.Eq(t, 5*time.Second, d)
+}
+
+func TestValue_Get_Slice(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Set(path.NewKeyPath("numbers"), []any{1, 2, 3})
+	root.Set(path.NewKeyPath("strings"), []any{"a", "b", "c"})
+
+	node := root.Get(path.NewKeyPath("numbers"))
+	val := tree.NewValue(node, path.NewKeyPath("numbers"))
+
+	var nums []int
+
+	err := val.Get(&nums)
+	must.NoError(t, err)
+	test.Eq(t, []int{1, 2, 3}, nums)
+
+	node = root.Get(path.NewKeyPath("strings"))
+	val = tree.NewValue(node, path.NewKeyPath("strings"))
+
+	var strs []string
+
+	err = val.Get(&strs)
+	must.NoError(t, err)
+	test.Eq(t, []string{"a", "b", "c"}, strs)
+}
+
+func TestValue_Get_Map(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	root.Set(path.NewKeyPath("person/name"), "Alice")
+	root.Set(path.NewKeyPath("person/age"), 30)
+	root.Set(path.NewKeyPath("person/active"), true)
+
+	node := root.Get(path.NewKeyPath("person"))
+	val := tree.NewValue(node, path.NewKeyPath("person"))
+
+	var m map[string]any
+
+	err := val.Get(&m)
+	must.NoError(t, err)
+	test.Eq(t, "Alice", m["name"])
+	test.Eq(t, 30, m["age"])
+	test.Eq(t, true, m["active"])
+}
+
+func TestValue_Get_Struct(t *testing.T) {
+	t.Parallel()
+
+	type Person struct {
+		Name   string `yaml:"name"`
+		Age    int    `yaml:"age"`
+		Active bool   `yaml:"active"`
+		Extra  string
+	}
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("person/name"), "Bob")
+	root.Set(path.NewKeyPath("person/age"), 25)
+	root.Set(path.NewKeyPath("person/active"), false)
+	root.Set(path.NewKeyPath("person/Extra"), "something")
+
+	node := root.Get(path.NewKeyPath("person"))
+	val := tree.NewValue(node, path.NewKeyPath("person"))
+
+	var person Person
+
+	err := val.Get(&person)
+	must.NoError(t, err)
+	test.Eq(t, "Bob", person.Name)
+	test.Eq(t, 25, person.Age)
+	test.False(t, person.Active)
+	test.Eq(t, "something", person.Extra)
+}
+
+func TestValue_Get_NestedStruct(t *testing.T) {
+	t.Parallel()
+
+	type Address struct {
+		City string `yaml:"city"`
+		Zip  int    `yaml:"zip"`
+	}
+
+	type User struct {
+		Name    string  `yaml:"name"`
+		Address Address `yaml:"address"`
+	}
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("user/name"), "Charlie")
+	root.Set(path.NewKeyPath("user/address/city"), "Moscow")
+	root.Set(path.NewKeyPath("user/address/zip"), 123456)
+
+	node := root.Get(path.NewKeyPath("user"))
+	val := tree.NewValue(node, path.NewKeyPath("user"))
+
+	var user User
+
+	err := val.Get(&user)
+	must.NoError(t, err)
+	test.Eq(t, "Charlie", user.Name)
+	test.Eq(t, "Moscow", user.Address.City)
+	test.Eq(t, 123456, user.Address.Zip)
+}
+
+func TestValue_Get_Pointer(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("value"), "pointer test")
+
+	node := root.Get(path.NewKeyPath("value"))
+	val := tree.NewValue(node, path.NewKeyPath("value"))
+
+	var ptr *string
+
+	err := val.Get(&ptr)
+	must.NoError(t, err)
+	must.NotNil(t, ptr)
+	test.Eq(t, "pointer test", *ptr)
+}
+
+func TestValue_Get_NonPointerError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("str"), "hello")
+
+	node := root.Get(path.NewKeyPath("str"))
+	val := tree.NewValue(node, path.NewKeyPath("str"))
+
+	var s string
+
+	err := val.Get(s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "pointer")
+}
+
+func TestValue_Get_NilPointerError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("str"), "hello")
+
+	node := root.Get(path.NewKeyPath("str"))
+	val := tree.NewValue(node, path.NewKeyPath("str"))
+
+	err := val.Get(nil)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "pointer")
+}
+
+func TestValue_Get_TypeMismatchError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("str"), "hello")
+
+	node := root.Get(path.NewKeyPath("str"))
+	val := tree.NewValue(node, path.NewKeyPath("str"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_IntFromInvalidString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notint"), "abc")
+
+	node := root.Get(path.NewKeyPath("notint"))
+	val := tree.NewValue(node, path.NewKeyPath("notint"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_FloatFromInvalidString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notfloat"), "xyz")
+
+	node := root.Get(path.NewKeyPath("notfloat"))
+	val := tree.NewValue(node, path.NewKeyPath("notfloat"))
+
+	var f float64
+
+	err := val.Get(&f)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_FloatFromVariousTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  any
+		want float64
+	}{
+		{"float32", float32(3.14), float64(float32(3.14))},
+		{"int8", int8(42), 42},
+		{"int16", int16(1000), 1000},
+		{"int32", int32(99999), 99999},
+		{"int64", int64(-5), -5},
+		{"uint8", uint8(255), 255},
+		{"uint16", uint16(65535), 65535},
+		{"uint32", uint32(4294967295), 4294967295},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := tree.New()
+			root.Set(path.NewKeyPath("val"), tt.src)
+
+			node := root.Get(path.NewKeyPath("val"))
+			val := tree.NewValue(node, path.NewKeyPath("val"))
+
+			var got float64
+
+			err := val.Get(&got)
+			must.NoError(t, err)
+			test.Eq(t, tt.want, got)
+		})
+	}
+}
+
+func TestValue_Get_BoolFromInvalidString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notbool"), "maybe")
+
+	node := root.Get(path.NewKeyPath("notbool"))
+	val := tree.NewValue(node, path.NewKeyPath("notbool"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_DurationFromInvalidString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notduration"), "10x")
+
+	node := root.Get(path.NewKeyPath("notduration"))
+	val := tree.NewValue(node, path.NewKeyPath("notduration"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "parse")
+}
+
+func TestValue_Get_UintFromNegativeFloatString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("negfloat"), "-1.5")
+
+	node := root.Get(path.NewKeyPath("negfloat"))
+	val := tree.NewValue(node, path.NewKeyPath("negfloat"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "invalid syntax")
+}
+
+func TestValue_Get_DurationFromUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notduration"), []any{1, 2})
+
+	node := root.Get(path.NewKeyPath("notduration"))
+	val := tree.NewValue(node, path.NewKeyPath("notduration"))
+
+	var dur time.Duration
+
+	err := val.Get(&dur)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "cannot convert")
+}
+
+func TestValue_Get_Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("big"), 1000)
+
+	node := root.Get(path.NewKeyPath("big"))
+	val := tree.NewValue(node, path.NewKeyPath("big"))
+
+	var u8 uint8
+
+	err := val.Get(&u8)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+
+	var i8 int8
+
+	err = val.Get(&i8)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+
+	root.Set(path.NewKeyPath("huge"), 1e50)
+
+	node = root.Get(path.NewKeyPath("huge"))
+	val = tree.NewValue(node, path.NewKeyPath("huge"))
+
+	var f32 float32
+
+	err = val.Get(&f32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_MapToStringConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("map/str"), "hello")
+	root.Set(path.NewKeyPath("map/num"), "42")
+	root.Set(path.NewKeyPath("map/bool"), "true")
+
+	node := root.Get(path.NewKeyPath("map"))
+	val := tree.NewValue(node, path.NewKeyPath("map"))
+
+	var m map[string]string
+
+	err := val.Get(&m)
+	must.NoError(t, err)
+	test.Eq(t, "hello", m["str"])
+	test.Eq(t, "42", m["num"])
+	test.Eq(t, "true", m["bool"])
+}
+
+func TestValue_Get_MapToIntConversionError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("map/str"), "hello")
+	root.Set(path.NewKeyPath("map/num"), "42")
+	root.Set(path.NewKeyPath("map/bool"), "true")
+
+	node := root.Get(path.NewKeyPath("map"))
+	val := tree.NewValue(node, path.NewKeyPath("map"))
+
+	var m map[string]int
+
+	err := val.Get(&m)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_MapFromSliceError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notmap"), []any{1, 2, 3})
+
+	node := root.Get(path.NewKeyPath("notmap"))
+	val := tree.NewValue(node, path.NewKeyPath("notmap"))
+
+	var m map[string]any
+
+	err := val.Get(&m)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "not a map")
+}
+
+func TestValue_Get_MapWithNonStringKeyError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("goodmap/foo"), "bar")
+
+	node := root.Get(path.NewKeyPath("goodmap"))
+	val := tree.NewValue(node, path.NewKeyPath("goodmap"))
+
+	var badMap map[int]string
+
+	err := val.Get(&badMap)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "must have string keys")
+}
+
+func TestValue_Get_Int8ToIntConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), int8(42))
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 42, i)
+}
+
+func TestValue_Get_Int16(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val16"), int16(1000))
+
+	node := root.Get(path.NewKeyPath("val16"))
+	val := tree.NewValue(node, path.NewKeyPath("val16"))
+
+	var i16 int16
+
+	err := val.Get(&i16)
+	must.NoError(t, err)
+	test.Eq(t, int16(1000), i16)
+}
+
+func TestValue_Get_Int32(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val32"), int32(100000))
+
+	node := root.Get(path.NewKeyPath("val32"))
+	val := tree.NewValue(node, path.NewKeyPath("val32"))
+
+	var i32 int32
+
+	err := val.Get(&i32)
+	must.NoError(t, err)
+	test.Eq(t, int32(100000), i32)
+}
+
+func TestValue_Get_Uint8(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("valu8"), uint8(200))
+
+	node := root.Get(path.NewKeyPath("valu8"))
+	val := tree.NewValue(node, path.NewKeyPath("valu8"))
+
+	var u8 uint8
+
+	err := val.Get(&u8)
+	must.NoError(t, err)
+	test.Eq(t, uint8(200), u8)
+}
+
+func TestValue_Get_Uint16(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("valu16"), uint16(50000))
+
+	node := root.Get(path.NewKeyPath("valu16"))
+	val := tree.NewValue(node, path.NewKeyPath("valu16"))
+
+	var u16 uint16
+
+	err := val.Get(&u16)
+	must.NoError(t, err)
+	test.Eq(t, uint16(50000), u16)
+}
+
+func TestValue_Get_Uint32(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("valu32"), uint32(3000000000))
+
+	node := root.Get(path.NewKeyPath("valu32"))
+	val := tree.NewValue(node, path.NewKeyPath("valu32"))
+
+	var u32 uint32
+
+	err := val.Get(&u32)
+	must.NoError(t, err)
+	test.Eq(t, uint32(3000000000), u32)
+}
+
+func TestValue_Get_DurationFromInt64(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("sec"), int64(5))
+
+	node := root.Get(path.NewKeyPath("sec"))
+	val := tree.NewValue(node, path.NewKeyPath("sec"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.NoError(t, err)
+	test.Eq(t, 5*time.Second, d)
+}
+
+func TestValue_Get_DurationFromUint64(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("usec"), uint64(5))
+
+	node := root.Get(path.NewKeyPath("usec"))
+	val := tree.NewValue(node, path.NewKeyPath("usec"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.NoError(t, err)
+	test.Eq(t, 5*time.Second, d)
+}
+
+func TestValue_Get_DurationFromFloat(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("floatsec"), 2.5)
+
+	node := root.Get(path.NewKeyPath("floatsec"))
+	val := tree.NewValue(node, path.NewKeyPath("floatsec"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.NoError(t, err)
+	test.Eq(t, time.Duration(2500000000), d)
+}
+
+func TestValue_Get_StringFromBytes(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("bytes"), []byte("hello bytes"))
+
+	node := root.Get(path.NewKeyPath("bytes"))
+	val := tree.NewValue(node, path.NewKeyPath("bytes"))
+
+	var s string
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "hello bytes", s)
+}
+
+func TestValue_Get_StringFromStringer(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("stringer"), testStringer{})
+
+	node := root.Get(path.NewKeyPath("stringer"))
+	val := tree.NewValue(node, path.NewKeyPath("stringer"))
+
+	var s string
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "I am a Stringer", s)
+}
+
+func TestValue_Get_StringFromInt(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("int"), 123)
+
+	node := root.Get(path.NewKeyPath("int"))
+	val := tree.NewValue(node, path.NewKeyPath("int"))
+
+	var s string
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "123", s)
+}
+
+func TestValue_Get_BoolFromZero(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("zero"), 0)
+
+	node := root.Get(path.NewKeyPath("zero"))
+	val := tree.NewValue(node, path.NewKeyPath("zero"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.False(t, b)
+}
+
+func TestValue_Get_BoolFromOne(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("one"), 1)
+
+	node := root.Get(path.NewKeyPath("one"))
+	val := tree.NewValue(node, path.NewKeyPath("one"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.True(t, b)
+}
+
+func TestValue_Get_BoolFromNegative(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("neg"), -5)
+
+	node := root.Get(path.NewKeyPath("neg"))
+	val := tree.NewValue(node, path.NewKeyPath("neg"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.True(t, b)
+}
+
+func TestValue_Get_BoolFromUint(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("uintval"), uint(10))
+
+	node := root.Get(path.NewKeyPath("uintval"))
+	val := tree.NewValue(node, path.NewKeyPath("uintval"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.NoError(t, err)
+	test.True(t, b)
+}
+
+func TestValue_Get_NilSource(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("nilval"), nil)
+
+	node := root.Get(path.NewKeyPath("nilval"))
+	val := tree.NewValue(node, path.NewKeyPath("nilval"))
+
+	var s string
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "", s)
+
+	var i int
+
+	err = val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 0, i)
+
+	var p *int
+
+	err = val.Get(&p)
+	must.NoError(t, err)
+	must.Nil(t, p)
+}
+
+func TestValue_Meta(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("test"), "value")
+
+	node := root.Get(path.NewKeyPath("test"))
+	must.NotNil(t, node)
+
+	node.Source = "file.yaml"
+	node.Revision = "42"
+
+	val := tree.NewValue(node, path.NewKeyPath("test"))
+	mi := val.Meta()
+	test.Eq(t, path.NewKeyPath("test"), mi.Key)
+	test.Eq(t, "file.yaml", mi.Source.Name)
+	test.Eq(t, meta.UnknownSource, mi.Source.Type)
+	test.Eq(t, "42", mi.Revision)
+}
+
+func TestValue_Get_Uint64ToInt64Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), uint64(1<<63))
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var i64 int64
+
+	err := val.Get(&i64)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_UintToIntOverflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), uint(1<<63))
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_IntFromBool(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("booltrue"), true)
+
+	node := root.Get(path.NewKeyPath("booltrue"))
+	val := tree.NewValue(node, path.NewKeyPath("booltrue"))
+
+	var got int
+
+	err := val.Get(&got)
+	must.NoError(t, err)
+	test.Eq(t, 1, got)
+
+	root.Set(path.NewKeyPath("boolfalse"), false)
+
+	node = root.Get(path.NewKeyPath("boolfalse"))
+	val = tree.NewValue(node, path.NewKeyPath("boolfalse"))
+
+	err = val.Get(&got)
+	must.NoError(t, err)
+	test.Eq(t, 0, got)
+}
+
+func TestValue_Get_Int16Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), 32768)
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var i16 int16
+
+	err := val.Get(&i16)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+
+	root.Set(path.NewKeyPath("small"), -32769)
+
+	node = root.Get(path.NewKeyPath("small"))
+	val = tree.NewValue(node, path.NewKeyPath("small"))
+
+	err = val.Get(&i16)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_Int32Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), int64(2147483648))
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var i32 int32
+
+	err := val.Get(&i32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+
+	root.Set(path.NewKeyPath("small"), int64(-2147483649))
+
+	node = root.Get(path.NewKeyPath("small"))
+	val = tree.NewValue(node, path.NewKeyPath("small"))
+
+	err = val.Get(&i32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_UintFromNegativeInt(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("neg"), -5)
+
+	node := root.Get(path.NewKeyPath("neg"))
+	val := tree.NewValue(node, path.NewKeyPath("neg"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "negative")
+}
+
+func TestValue_Get_UintFromNegativeFloat(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("neg"), -3.14)
+
+	node := root.Get(path.NewKeyPath("neg"))
+	val := tree.NewValue(node, path.NewKeyPath("neg"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "negative")
+}
+
+func TestValue_Get_UintFromNegativeFloat32(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("neg"), float32(-3.14))
+
+	node := root.Get(path.NewKeyPath("neg"))
+	val := tree.NewValue(node, path.NewKeyPath("neg"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "negative")
+}
+
+func TestValue_Get_Uint16Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), 65536)
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var u16 uint16
+
+	err := val.Get(&u16)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_Uint32Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), uint64(4294967296))
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var u32 uint32
+
+	err := val.Get(&u32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_UintFromBool(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("booltrue"), true)
+
+	node := root.Get(path.NewKeyPath("booltrue"))
+	val := tree.NewValue(node, path.NewKeyPath("booltrue"))
+
+	var got uint
+
+	err := val.Get(&got)
+	must.NoError(t, err)
+	test.Eq(t, uint(1), got)
+
+	root.Set(path.NewKeyPath("boolfalse"), false)
+
+	node = root.Get(path.NewKeyPath("boolfalse"))
+	val = tree.NewValue(node, path.NewKeyPath("boolfalse"))
+
+	err = val.Get(&got)
+	must.NoError(t, err)
+	test.Eq(t, uint(0), got)
+}
+
+func TestValue_Get_UintFromInvalidString(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("invalid"), "abc")
+
+	node := root.Get(path.NewKeyPath("invalid"))
+	val := tree.NewValue(node, path.NewKeyPath("invalid"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_UintFromVariousTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  any
+		want uint64
+	}{
+		{"uint", uint(42), 42},
+		{"uint8", uint8(255), 255},
+		{"uint16", uint16(65535), 65535},
+		{"uint32", uint32(4294967295), 4294967295},
+		{"float32 positive", float32(3.14), 3},
+		{"string positive", "12345", 12345},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := tree.New()
+			root.Set(path.NewKeyPath("val"), tt.src)
+
+			node := root.Get(path.NewKeyPath("val"))
+			val := tree.NewValue(node, path.NewKeyPath("val"))
+
+			var got uint64
+
+			err := val.Get(&got)
+			must.NoError(t, err)
+			test.Eq(t, tt.want, got)
+		})
+	}
+}
+
+func TestValue_Get_UintFromUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), []int{1, 2, 3})
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert to uint")
+}
+
+func TestValue_Get_Float32Overflow(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("huge"), 1e100)
+
+	node := root.Get(path.NewKeyPath("huge"))
+	val := tree.NewValue(node, path.NewKeyPath("huge"))
+
+	var f32 float32
+
+	err := val.Get(&f32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+
+	root.Set(path.NewKeyPath("negHuge"), -1e100)
+
+	node = root.Get(path.NewKeyPath("negHuge"))
+	val = tree.NewValue(node, path.NewKeyPath("negHuge"))
+
+	err = val.Get(&f32)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_FloatFromUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("unsupported"), []any{1, 2})
+
+	node := root.Get(path.NewKeyPath("unsupported"))
+	val := tree.NewValue(node, path.NewKeyPath("unsupported"))
+
+	var f float64
+
+	err := val.Get(&f)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_BoolFromUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("unsupported"), []any{1, 2})
+
+	node := root.Get(path.NewKeyPath("unsupported"))
+	val := tree.NewValue(node, path.NewKeyPath("unsupported"))
+
+	var b bool
+
+	err := val.Get(&b)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_SliceFromNonSliceError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notslice"), "string")
+
+	node := root.Get(path.NewKeyPath("notslice"))
+	val := tree.NewValue(node, path.NewKeyPath("notslice"))
+
+	var s []int
+
+	err := val.Get(&s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "not a slice")
+}
+
+func TestValue_Get_MapKeyNotStringError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("badmap"), map[int]string{1: "foo"})
+
+	node := root.Get(path.NewKeyPath("badmap"))
+	val := tree.NewValue(node, path.NewKeyPath("badmap"))
+
+	var m map[string]string
+
+	err := val.Get(&m)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "key is not string")
+}
+
+func TestValue_Get_StructSourceNotMapError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("notmap"), "string")
+
+	node := root.Get(path.NewKeyPath("notmap"))
+	val := tree.NewValue(node, path.NewKeyPath("notmap"))
+
+	type S struct {
+		Field string `yaml:"field"`
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "must be a map")
+}
+
+func TestValue_Get_StructMapKeyNotStringError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("badmap"), map[int]string{1: "foo"})
+
+	node := root.Get(path.NewKeyPath("badmap"))
+	val := tree.NewValue(node, path.NewKeyPath("badmap"))
+
+	type S struct {
+		Field string `yaml:"field"`
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "must have string keys")
+}
+
+func TestValue_Get_StructFieldDecodeError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("struct/int"), "abc")
+
+	node := root.Get(path.NewKeyPath("struct"))
+	val := tree.NewValue(node, path.NewKeyPath("struct"))
+
+	type S struct {
+		Int int `yaml:"int"`
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert")
+}
+
+func TestValue_Get_StructUnexportedField(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("struct/exported"), "hello")
+	root.Set(path.NewKeyPath("struct/unexported"), "world")
+
+	node := root.Get(path.NewKeyPath("struct"))
+	val := tree.NewValue(node, path.NewKeyPath("struct"))
+
+	type S struct {
+		Exported   string `yaml:"exported"`
+		unexported string
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "hello", s.Exported)
+	test.Eq(t, "", s.unexported)
+}
+
+func TestValue_Get_StructYamlTagComma(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("struct/myfield"), "value")
+
+	node := root.Get(path.NewKeyPath("struct"))
+	val := tree.NewValue(node, path.NewKeyPath("struct"))
+
+	type S struct {
+		Field string `yaml:"myfield,omitempty"`
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "value", s.Field)
+}
+
+func TestValue_Get_StructMissingField(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("struct/present"), "hello")
+
+	node := root.Get(path.NewKeyPath("struct"))
+	val := tree.NewValue(node, path.NewKeyPath("struct"))
+
+	type S struct {
+		Present string `yaml:"present"`
+		Missing string `yaml:"missing"`
+	}
+
+	var s S
+
+	err := val.Get(&s)
+	must.NoError(t, err)
+	test.Eq(t, "hello", s.Present)
+	test.Eq(t, "", s.Missing)
+}
+
+func TestValue_Get_DurationOverflowInt64(t *testing.T) {
+	t.Parallel()
+
+	maxSafeSeconds := math.MaxInt64 / int64(time.Second)
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), maxSafeSeconds+1)
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_DurationOverflowUint64(t *testing.T) {
+	t.Parallel()
+
+	maxSafeUintSeconds := uint64(math.MaxInt64 / int64(time.Second))
+	root := tree.New()
+	root.Set(path.NewKeyPath("large"), maxSafeUintSeconds+1)
+
+	node := root.Get(path.NewKeyPath("large"))
+	val := tree.NewValue(node, path.NewKeyPath("large"))
+
+	var d time.Duration
+
+	err := val.Get(&d)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "overflow")
+}
+
+func TestValue_Get_UnsupportedDestinationType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), 123)
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var c complex64
+
+	err := val.Get(&c)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+}
+
+func TestValue_Get_InterfaceImplemented(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("stringer"), testStringer{})
+
+	node := root.Get(path.NewKeyPath("stringer"))
+	val := tree.NewValue(node, path.NewKeyPath("stringer"))
+
+	var iface fmt.Stringer
+
+	err := val.Get(&iface)
+	must.NoError(t, err)
+	test.Eq(t, "I am a Stringer", iface.String())
+}
+
+func TestValue_Get_InterfaceEmpty(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), 42)
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var iface any
+
+	err := val.Get(&iface)
+	must.NoError(t, err)
+	test.Eq(t, 42, iface)
+}
+
+func TestValue_Get_IntFromUint(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), uint(42))
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 42, i)
+}
+
+func TestValue_Get_Int64FromUint64(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), uint64(1234567890))
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var i64 int64
+
+	err := val.Get(&i64)
+	must.NoError(t, err)
+	test.Eq(t, int64(1234567890), i64)
+}
+
+func TestValue_Get_IntFromFloat(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), 3.0)
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.NoError(t, err)
+	test.Eq(t, 3, i)
+}
+
+func TestValue_Get_UintFromFloat(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), 5.0)
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var u uint
+
+	err := val.Get(&u)
+	must.NoError(t, err)
+	test.Eq(t, uint(5), u)
+}
+
+func TestValue_Get_IntFromVariousTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  any
+		want int64
+	}{
+		{"int8", int8(42), 42},
+		{"int16", int16(1000), 1000},
+		{"int32", int32(99999), 99999},
+		{"int64", int64(-5), -5},
+		{"uint8", uint8(255), 255},
+		{"uint16", uint16(65535), 65535},
+		{"uint32", uint32(4294967295), 4294967295},
+		{"float32", float32(3.14), 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := tree.New()
+			root.Set(path.NewKeyPath("val"), tt.src)
+
+			node := root.Get(path.NewKeyPath("val"))
+			val := tree.NewValue(node, path.NewKeyPath("val"))
+
+			var got int64
+
+			err := val.Get(&got)
+			must.NoError(t, err)
+			test.Eq(t, tt.want, got)
+		})
+	}
+}
+
+func TestValue_Get_IntFromUnsupportedType(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), []int{1, 2, 3})
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var i int
+
+	err := val.Get(&i)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "convert to int")
+}
+
+func TestValue_Get_BoolFromNumericTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  any
+		want bool
+	}{
+		{"int8 positive", int8(5), true},
+		{"int8 zero", int8(0), false},
+		{"int16 positive", int16(256), true},
+		{"int16 zero", int16(0), false},
+		{"int32 positive", int32(1000), true},
+		{"int32 zero", int32(0), false},
+		{"int64 positive", int64(-1), true},
+		{"int64 zero", int64(0), false},
+		{"uint8 positive", uint8(1), true},
+		{"uint8 zero", uint8(0), false},
+		{"uint16 positive", uint16(65535), true},
+		{"uint16 zero", uint16(0), false},
+		{"uint32 positive", uint32(40000), true},
+		{"uint32 zero", uint32(0), false},
+		{"uint64 positive", uint64(999), true},
+		{"uint64 zero", uint64(0), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := tree.New()
+			root.Set(path.NewKeyPath("val"), tt.val)
+
+			node := root.Get(path.NewKeyPath("val"))
+			val := tree.NewValue(node, path.NewKeyPath("val"))
+
+			var b bool
+
+			err := val.Get(&b)
+			must.NoError(t, err)
+			test.Eq(t, tt.want, b)
+		})
+	}
+}
+
+func TestValue_Get_SliceElementConversionError(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("slice"), []any{1, "abc", 3})
+
+	node := root.Get(path.NewKeyPath("slice"))
+	val := tree.NewValue(node, path.NewKeyPath("slice"))
+
+	var s []int
+
+	err := val.Get(&s)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "slice element")
+}
+
+func TestValue_Get_UnsupportedDestinationKinds(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(path.NewKeyPath("val"), 123)
+
+	node := root.Get(path.NewKeyPath("val"))
+	val := tree.NewValue(node, path.NewKeyPath("val"))
+
+	var arr [1]int
+
+	err := val.Get(&arr)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var ch chan int
+
+	err = val.Get(&ch)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var fn func()
+
+	err = val.Get(&fn)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var up unsafe.Pointer
+
+	err = val.Get(&up)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var ui uintptr
+
+	err = val.Get(&ui)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var c64 complex64
+
+	err = val.Get(&c64)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+
+	var c128 complex128
+
+	err = val.Get(&c128)
+	must.Error(t, err)
+	test.StrContains(t, err.Error(), "unsupported")
+}

--- a/keypath.go
+++ b/keypath.go
@@ -1,151 +1,21 @@
 package config
 
-import (
-	"slices"
-	"strings"
-)
+import "github.com/tarantool/go-config/path"
 
 // KeyPath represents a hierarchical key.
 //
 // For example, for the key "/server/http/port" it will look like
 // []string{"server", "http", "port"}.
-type KeyPath []string
+type KeyPath = path.KeyPath
 
 // NewKeyPath creates a KeyPath from a string, splitting it by "/" slash.
 // This is the main way to create a path from a textual representation.
-func NewKeyPath(path string) KeyPath {
-	return NewKeyPathWithDelim(path, "/")
+func NewKeyPath(p string) KeyPath {
+	return path.NewKeyPath(p)
 }
 
 // NewKeyPathWithDelim creates a KeyPath from a string, splitting it by the given delimiter.
 // All segments are preserved, including empty ones.
-func NewKeyPathWithDelim(path, delim string) KeyPath {
-	if path == "" {
-		return KeyPath{}
-	}
-
-	return strings.Split(path, delim)
-}
-
-// String returns a textual representation of the path with slash ("/") as the delimiter.
-func (p KeyPath) String() string {
-	return p.MakeString("/")
-}
-
-// MakeString returns a textual representation of the path with the given delimiter.
-func (p KeyPath) MakeString(delim string) string {
-	return strings.Join(p, delim)
-}
-
-// Parent returns the parent path.
-// If the path consists of one element or is empty, returns nil.
-func (p KeyPath) Parent() KeyPath {
-	if len(p) <= 1 {
-		return nil
-	}
-
-	return p[:len(p)-1]
-}
-
-// Leaf returns the last segment of the path.
-// If the path is empty, returns an empty string.
-func (p KeyPath) Leaf() string {
-	if len(p) == 0 {
-		return ""
-	}
-
-	return p[len(p)-1]
-}
-
-// Append adds new segment(s) to the path, returning a new KeyPath.
-// The original path is not changed (immutability).
-func (p KeyPath) Append(segments ...string) KeyPath {
-	if len(segments) == 0 {
-		return p
-	}
-
-	newPath := make(KeyPath, 0, len(p)+len(segments))
-
-	newPath = append(append(newPath, p...), segments...)
-
-	return newPath
-}
-
-// Equals checks that two paths are completely identical.
-func (p KeyPath) Equals(other KeyPath) bool {
-	if len(p) != len(other) {
-		return false
-	}
-
-	for i := range p {
-		if p[i] != other[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
-// Match checks whether the path matches a pattern using wildcards.
-// A wildcard is "*", which matches any single segment.
-// A double wildcard "**" matches zero or more segments.
-// Pattern matches if it is a prefix of the path (pattern length <= path length).
-// For example, pattern "a/*/c" matches path "a/b/c".
-// Pattern "a/*/c" also matches path "a/b/c/d" (since pattern is prefix).
-// Pattern "a/**/c" matches path "a/b/c", "a/x/y/c", and "a/c".
-func (p KeyPath) Match(pattern KeyPath) bool {
-	var (
-		pointerI          = 0
-		pointerJ          = 0
-		backtrackPointerI = -1
-		backtrackPointerJ = -1
-	)
-
-	for pointerI < len(p) && pointerJ < len(pattern) {
-		seg := pattern[pointerJ]
-		if seg == "*" {
-			pointerI++
-
-			pointerJ++
-
-			continue
-		}
-
-		if seg == "**" {
-			backtrackPointerI = pointerI
-			backtrackPointerJ = pointerJ
-			pointerJ++
-
-			continue
-		}
-
-		if seg == p[pointerI] {
-			pointerI++
-
-			pointerJ++
-
-			continue
-		}
-
-		if backtrackPointerJ >= 0 {
-			pointerI = backtrackPointerI + 1
-			pointerJ = backtrackPointerJ
-			backtrackPointerI = pointerI
-
-			continue
-		}
-
-		return false
-	}
-
-	for pointerJ < len(pattern) && pattern[pointerJ] == "**" {
-		pointerJ++
-	}
-
-	return pointerJ == len(pattern)
-}
-
-// HasEmptySegment returns true if the path contains any empty segment ("").
-func (p KeyPath) HasEmptySegment() bool {
-	return slices.Contains(p, "")
+func NewKeyPathWithDelim(p, delim string) KeyPath {
+	return path.NewKeyPathWithDelim(p, delim)
 }

--- a/meta/doc.go
+++ b/meta/doc.go
@@ -1,0 +1,2 @@
+// Package meta provides metadata types for configuration values.
+package meta

--- a/meta/info.go
+++ b/meta/info.go
@@ -1,0 +1,16 @@
+package meta
+
+import (
+	"github.com/tarantool/go-config/path"
+)
+
+// Info contains metadata about a value in the configuration.
+// Used to display the actual origin of the obtained value.
+type Info struct {
+	// Key corresponds to the actual location of the value.
+	Key path.KeyPath
+	// Source information about the source/collector from which the value was obtained.
+	Source SourceInfo
+	// Revision number, if applicable.
+	Revision RevisionType
+}

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -1,0 +1,108 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/shoenig/test"
+
+	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/path"
+)
+
+func TestSourceType_ConstantsExist(t *testing.T) {
+	t.Parallel()
+
+	// Verify all constants are defined.
+	test.Eq(t, meta.UnknownSource, meta.SourceType(0))
+	test.Eq(t, meta.EnvDefaultSource, meta.SourceType(1))
+	test.Eq(t, meta.StorageSource, meta.SourceType(2))
+	test.Eq(t, meta.FileSource, meta.SourceType(3))
+	test.Eq(t, meta.EnvSource, meta.SourceType(4))
+	test.Eq(t, meta.ModifiedSource, meta.SourceType(5))
+}
+
+func TestSourceInfo_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var si meta.SourceInfo
+	test.Eq(t, "", si.Name)
+	test.Eq(t, meta.SourceType(0), si.Type)
+}
+
+func TestSourceInfo_WithFields(t *testing.T) {
+	t.Parallel()
+
+	si := meta.SourceInfo{
+		Name: "testfile",
+		Type: meta.FileSource,
+	}
+	test.Eq(t, "testfile", si.Name)
+	test.Eq(t, meta.FileSource, si.Type)
+}
+
+func TestInfo_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var info meta.Info
+	test.Eq(t, path.KeyPath(nil), info.Key)
+	test.Eq(t, meta.SourceInfo{Name: "", Type: meta.UnknownSource}, info.Source)
+	test.Eq(t, meta.RevisionType(""), info.Revision)
+}
+
+func TestInfo_WithKey(t *testing.T) {
+	t.Parallel()
+
+	key := path.NewKeyPath("a/b/c")
+	info := meta.Info{
+		Key:      key,
+		Source:   meta.SourceInfo{Name: "", Type: meta.UnknownSource},
+		Revision: "",
+	}
+	test.True(t, info.Key.Equals(key))
+}
+
+func TestInfo_WithSource(t *testing.T) {
+	t.Parallel()
+
+	source := meta.SourceInfo{
+		Name: "env",
+		Type: meta.EnvSource,
+	}
+	info := meta.Info{
+		Key:      nil,
+		Source:   source,
+		Revision: "",
+	}
+	test.Eq(t, "env", info.Source.Name)
+	test.Eq(t, meta.EnvSource, info.Source.Type)
+}
+
+func TestInfo_WithRevision(t *testing.T) {
+	t.Parallel()
+
+	info := meta.Info{
+		Key:      nil,
+		Source:   meta.SourceInfo{Name: "", Type: meta.UnknownSource},
+		Revision: "v1.0.0",
+	}
+	test.Eq(t, meta.RevisionType("v1.0.0"), info.Revision)
+}
+
+func TestInfo_FullConstruction(t *testing.T) {
+	t.Parallel()
+
+	key := path.NewKeyPath("server/port")
+	source := meta.SourceInfo{
+		Name: "config.yaml",
+		Type: meta.FileSource,
+	}
+	info := meta.Info{
+		Key:      key,
+		Source:   source,
+		Revision: "abc123",
+	}
+	test.True(t, info.Key.Equals(key))
+	test.Eq(t, "config.yaml", info.Source.Name)
+	test.Eq(t, meta.FileSource, info.Source.Type)
+	test.Eq(t, meta.RevisionType("abc123"), info.Revision)
+}

--- a/meta/revisiontype.go
+++ b/meta/revisiontype.go
@@ -1,0 +1,5 @@
+package meta
+
+// RevisionType defines a revision identifier of configuration, if applicable.
+// Typically, a string (e.g., commit hash, timestamp). If revision is not supported, it should be empty.
+type RevisionType string

--- a/meta/sourceinfo.go
+++ b/meta/sourceinfo.go
@@ -1,0 +1,9 @@
+package meta
+
+// SourceInfo contains information about the source where the value originated.
+type SourceInfo struct {
+	// Name of the source where the value was obtained.
+	Name string
+	// Type of the source (file, environment variable, etc.).
+	Type SourceType
+}

--- a/meta/sourcetype.go
+++ b/meta/sourcetype.go
@@ -1,0 +1,19 @@
+package meta
+
+// SourceType defines the type of configuration source.
+type SourceType int
+
+const (
+	// UnknownSource indicates an undefined source.
+	UnknownSource SourceType = iota
+	// EnvDefaultSource indicates default values from environment variables (e.g., TT_FOO_DEFAULT).
+	EnvDefaultSource
+	// StorageSource indicates an external centralized storage (e.g., Etcd or TcS).
+	StorageSource
+	// FileSource indicates a local file.
+	FileSource
+	// EnvSource indicates environment variables.
+	EnvSource
+	// ModifiedSource indicates dynamically modified data (e.g., at runtime) for MutableConfig.
+	ModifiedSource
+)

--- a/path/doc.go
+++ b/path/doc.go
@@ -1,0 +1,2 @@
+// Package path provides key path manipulation for configuration hierarchy.
+package path

--- a/path/keypath.go
+++ b/path/keypath.go
@@ -1,0 +1,151 @@
+package path
+
+import (
+	"slices"
+	"strings"
+)
+
+// KeyPath represents a hierarchical key.
+//
+// For example, for the key "/server/http/port" it will look like
+// []string{"server", "http", "port"}.
+type KeyPath []string
+
+// NewKeyPath creates a KeyPath from a string, splitting it by "/" slash.
+// This is the main way to create a path from a textual representation.
+func NewKeyPath(path string) KeyPath {
+	return NewKeyPathWithDelim(path, "/")
+}
+
+// NewKeyPathWithDelim creates a KeyPath from a string, splitting it by the given delimiter.
+// All segments are preserved, including empty ones.
+func NewKeyPathWithDelim(path, delim string) KeyPath {
+	if path == "" {
+		return KeyPath{}
+	}
+
+	return strings.Split(path, delim)
+}
+
+// String returns a textual representation of the path with slash ("/") as the delimiter.
+func (p KeyPath) String() string {
+	return p.MakeString("/")
+}
+
+// MakeString returns a textual representation of the path with the given delimiter.
+func (p KeyPath) MakeString(delim string) string {
+	return strings.Join(p, delim)
+}
+
+// Parent returns the parent path.
+// If the path consists of one element or is empty, returns nil.
+func (p KeyPath) Parent() KeyPath {
+	if len(p) <= 1 {
+		return nil
+	}
+
+	return p[:len(p)-1]
+}
+
+// Leaf returns the last segment of the path.
+// If the path is empty, returns an empty string.
+func (p KeyPath) Leaf() string {
+	if len(p) == 0 {
+		return ""
+	}
+
+	return p[len(p)-1]
+}
+
+// Append adds new segment(s) to the path, returning a new KeyPath.
+// The original path is not changed (immutability).
+func (p KeyPath) Append(segments ...string) KeyPath {
+	if len(segments) == 0 {
+		return p
+	}
+
+	newPath := make(KeyPath, 0, len(p)+len(segments))
+
+	newPath = append(append(newPath, p...), segments...)
+
+	return newPath
+}
+
+// Equals checks that two paths are completely identical.
+func (p KeyPath) Equals(other KeyPath) bool {
+	if len(p) != len(other) {
+		return false
+	}
+
+	for i := range p {
+		if p[i] != other[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Match checks whether the path matches a pattern using wildcards.
+// A wildcard is "*", which matches any single segment.
+// A double wildcard "**" matches zero or more segments.
+// Pattern matches if it is a prefix of the path (pattern length <= path length).
+// For example, pattern "a/*/c" matches path "a/b/c".
+// Pattern "a/*/c" also matches path "a/b/c/d" (since pattern is prefix).
+// Pattern "a/**/c" matches path "a/b/c", "a/x/y/c", and "a/c".
+func (p KeyPath) Match(pattern KeyPath) bool {
+	var (
+		pointerI          = 0
+		pointerJ          = 0
+		backtrackPointerI = -1
+		backtrackPointerJ = -1
+	)
+
+	for pointerI < len(p) && pointerJ < len(pattern) {
+		seg := pattern[pointerJ]
+		if seg == "*" {
+			pointerI++
+
+			pointerJ++
+
+			continue
+		}
+
+		if seg == "**" {
+			backtrackPointerI = pointerI
+			backtrackPointerJ = pointerJ
+			pointerJ++
+
+			continue
+		}
+
+		if seg == p[pointerI] {
+			pointerI++
+
+			pointerJ++
+
+			continue
+		}
+
+		if backtrackPointerJ >= 0 {
+			pointerI = backtrackPointerI + 1
+			pointerJ = backtrackPointerJ
+			backtrackPointerI = pointerI
+
+			continue
+		}
+
+		return false
+	}
+
+	for pointerJ < len(pattern) && pattern[pointerJ] == "**" {
+		pointerJ++
+	}
+
+	return pointerJ == len(pattern)
+}
+
+// HasEmptySegment returns true if the path contains any empty segment ("").
+func (p KeyPath) HasEmptySegment() bool {
+	return slices.Contains(p, "")
+}

--- a/path/keypath_test.go
+++ b/path/keypath_test.go
@@ -1,0 +1,303 @@
+package path_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shoenig/test"
+
+	"github.com/tarantool/go-config/path"
+)
+
+func formatTestName(in string) string {
+	return strings.ReplaceAll(in, "/", "_")
+}
+
+func TestNewKeyPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected path.KeyPath
+	}{
+		{"", path.KeyPath{}},
+		{"a", path.KeyPath{"a"}},
+		{"a/b", path.KeyPath{"a", "b"}},
+		{"a/b/c", path.KeyPath{"a", "b", "c"}},
+		{"/a/b", path.KeyPath{"", "a", "b"}},
+		{"a//c", path.KeyPath{"a", "", "c"}},
+		{"a/", path.KeyPath{"a", ""}},
+		{"/", path.KeyPath{"", ""}},
+		{"//a//b//", path.KeyPath{"", "", "a", "", "b", "", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.input), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, path.NewKeyPath(tt.input))
+			// Equal method works the same way as eq comparison.
+			test.True(t, path.NewKeyPath(tt.input).Equals(tt.expected))
+		})
+	}
+}
+
+func TestNewKeyPathWithDelim(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		delim    string
+		expected path.KeyPath
+	}{
+		{"a.b.c", ".", path.KeyPath{"a", "b", "c"}},
+		{"a..c", ".", path.KeyPath{"a", "", "c"}},
+		{"a|b", "|", path.KeyPath{"a", "b"}},
+		{"", ".", path.KeyPath{}},
+		{".a.b.", ".", path.KeyPath{"", "a", "b", ""}},
+		{"..a..b..", ".", path.KeyPath{"", "", "a", "", "b", "", ""}},
+		{"|a||b|", "|", path.KeyPath{"", "a", "", "b", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.input), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, path.NewKeyPathWithDelim(tt.input, tt.delim))
+			// Equal method works the same way as eq comparison.
+			test.True(t, path.NewKeyPathWithDelim(tt.input, tt.delim).Equals(tt.expected))
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		expected string
+	}{
+		{path.KeyPath{}, ""},
+		{path.KeyPath{"a"}, "a"},
+		{path.KeyPath{"a", "b"}, "a/b"},
+		{path.KeyPath{"", "a", "b"}, "/a/b"},
+		{path.KeyPath{"a", "", "c"}, "a//c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.String())
+		})
+	}
+}
+
+func TestMakeString(t *testing.T) {
+	t.Parallel()
+
+	kp := path.KeyPath{"a", "b", "c"}
+	test.Eq(t, "a.b.c", kp.MakeString("."))
+	test.Eq(t, "a|b|c", kp.MakeString("|"))
+}
+
+func TestParent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		expected path.KeyPath
+	}{
+		{path.KeyPath{}, nil},
+		{path.KeyPath{"a"}, nil},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a"}},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Parent())
+		})
+	}
+}
+
+func TestLeaf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		expected string
+	}{
+		{path.KeyPath{}, ""},
+		{path.KeyPath{"a"}, "a"},
+		{path.KeyPath{"a", "b"}, "b"},
+		{path.KeyPath{"a", "b", "c"}, "c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path.String(), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Leaf())
+		})
+	}
+}
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+
+	kp := path.KeyPath{"a", "b"}
+	got := kp.Append("c", "d")
+
+	test.Eq(t, path.KeyPath{"a", "b", "c", "d"}, got)
+	// Original KeyPath is unchanged.
+	test.Eq(t, path.KeyPath{"a", "b"}, kp)
+}
+
+func TestEquals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		a        path.KeyPath
+		b        path.KeyPath
+		expected bool
+	}{
+		{path.KeyPath{}, path.KeyPath{}, true},
+		{path.KeyPath{"a"}, path.KeyPath{"a"}, true},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "b"}, true},
+		{path.KeyPath{"a"}, path.KeyPath{"b"}, false},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a"}, false},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.a.String()+"_"+tt.b.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.a.Equals(tt.b))
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		pattern  path.KeyPath
+		expected bool
+	}{
+		// Exact matches.
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b", "c"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b", "d"}, false},
+		// Wildcard as "*".
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "*", "c"}, true},
+		{path.KeyPath{"a", "x", "c"}, path.KeyPath{"a", "*", "c"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"*", "b", "c"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b", "*"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"*", "*", "*"}, true},
+		// Empty segment is NOT a wildcard.
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "", "c"}, false},
+		{path.KeyPath{"a", "x", "c"}, path.KeyPath{"a", "", "c"}, false},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"", "b", "c"}, false},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b", ""}, false},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"", "", ""}, false},
+		// Length mismatch: pattern shorter than path (prefix match).
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "b"}, true},
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"a", "b"}, true},
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"a", "*"}, true},
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"*", "b"}, true},
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"a", "*", "c"}, true},
+		// Length mismatch: pattern longer than path.
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "b", "c"}, false},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "b", "*"}, false},
+		// Multiple wildcards.
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"a", "*", "c", "*"}, true},
+		{path.KeyPath{"a", "x", "c", "y"}, path.KeyPath{"a", "*", "c", "*"}, true},
+		{path.KeyPath{"a", "x", "c", "y"}, path.KeyPath{"a", "*", "d", "*"}, false},
+		// Empty path and pattern.
+		{path.KeyPath{}, path.KeyPath{}, true},
+		{path.KeyPath{}, path.KeyPath{""}, false},
+		{path.KeyPath{""}, path.KeyPath{}, true},
+		{path.KeyPath{"a"}, path.KeyPath{}, true},
+		// RFC example: pattern "/groups/*/replicasets/*/instances" should match path with extra segments.
+		{path.KeyPath{"groups", "storages", "replicasets", "storage-001", "instances", "storage-001-a"},
+			path.KeyPath{"groups", "*", "replicasets", "*", "instances"}, true},
+		{path.KeyPath{"groups", "storages", "replicasets", "storage-001", "instances"},
+			path.KeyPath{"groups", "*", "replicasets", "*", "instances"}, true},
+		{path.KeyPath{"groups", "storages", "replicasets", "storage-001"},
+			path.KeyPath{"groups", "*", "replicasets", "*", "instances"}, false},
+		// Wildcard * should match exactly one segment.
+		{path.KeyPath{"a", "c", "d", "b"}, path.KeyPath{"a", "*", "b"}, false},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "*", "b"}, false},
+		{path.KeyPath{"a"}, path.KeyPath{"a", "*"}, false},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"*", "b"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"*", "b", "*"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()+"_"+tt.pattern.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.Match(tt.pattern))
+		})
+	}
+}
+
+func TestHasEmptySegment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		expected bool
+	}{
+		{path.KeyPath{}, false},
+		{path.KeyPath{"a"}, false},
+		{path.KeyPath{"a", "b", "c"}, false},
+		{path.KeyPath{"a", "", "c"}, true},
+		{path.KeyPath{"", "a", "b"}, true},
+		{path.KeyPath{"a", "b", ""}, true},
+		{path.KeyPath{"", "", ""}, true},
+		{path.KeyPath{"", "a", "", "b", ""}, true},
+		{path.NewKeyPath("a//c"), true},
+		{path.NewKeyPath("/a/b"), true},
+		{path.NewKeyPath("a/"), true},
+		{path.NewKeyPath("//a//b//"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()), func(t *testing.T) {
+			t.Parallel()
+
+			test.Eq(t, tt.expected, tt.path.HasEmptySegment())
+		})
+	}
+}
+
+func TestMatchDoubleStar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     path.KeyPath
+		pattern  path.KeyPath
+		expected bool
+	}{
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "**", "b"}, true},
+		{path.KeyPath{"a", "x", "b"}, path.KeyPath{"a", "**", "b"}, true},
+		{path.KeyPath{"a", "x", "y", "z", "b"}, path.KeyPath{"a", "**", "b"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"a", "**"}, true},
+		{path.KeyPath{"a", "b", "c"}, path.KeyPath{"**", "c"}, true},
+		{path.KeyPath{"a", "b", "c", "d"}, path.KeyPath{"a", "*", "**", "d"}, true},
+		{path.KeyPath{"a", "b", "c", "d", "e"}, path.KeyPath{"a", "**", "c", "**", "e"}, true},
+		{path.KeyPath{"a", "b"}, path.KeyPath{"a", "**", "c"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(formatTestName(tt.path.String()+"_"+tt.pattern.String()), func(t *testing.T) {
+			t.Parallel()
+			test.Eq(t, tt.expected, tt.path.Match(tt.pattern))
+		})
+	}
+}

--- a/value.go
+++ b/value.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/value"
+)
+
+// SourceType defines the type of configuration source.
+type SourceType = meta.SourceType
+
+const (
+	// UnknownSource indicates an undefined source.
+	UnknownSource = meta.UnknownSource
+	// EnvDefaultSource indicates default values from environment variables (e.g., TT_FOO_DEFAULT).
+	EnvDefaultSource = meta.EnvDefaultSource
+	// StorageSource indicates an external centralized storage (e.g., Etcd or TcS).
+	StorageSource = meta.StorageSource
+	// FileSource indicates a local file.
+	FileSource = meta.FileSource
+	// EnvSource indicates environment variables.
+	EnvSource = meta.EnvSource
+	// ModifiedSource indicates dynamically modified data (e.g., at runtime) for MutableConfig.
+	ModifiedSource = meta.ModifiedSource
+)
+
+// RevisionType defines a revision identifier of configuration, if applicable.
+// Typically a string (e.g., commit hash, timestamp). If revision is not supported, it should be empty.
+type RevisionType = meta.RevisionType
+
+// SourceInfo contains information about the source where the value originated.
+type SourceInfo = meta.SourceInfo
+
+// MetaInfo contains metadata about a value in the configuration.
+// Used to display the actual origin of the obtained value.
+type MetaInfo = meta.Info
+
+// Value represents a single value in the configuration.
+type Value = value.Value

--- a/value/doc.go
+++ b/value/doc.go
@@ -1,0 +1,2 @@
+// Package value defines the Value interface for configuration values.
+package value

--- a/value/value.go
+++ b/value/value.go
@@ -1,0 +1,16 @@
+package value
+
+import "github.com/tarantool/go-config/meta"
+
+// Value represents a single value in the configuration.
+type Value interface {
+	// Get is the main method for data extraction. It attempts
+	// to convert and write the internal value into the variable `dest`,
+	// passed by pointer. The type conversion logic is similar
+	// to standard libraries such as `json.Unmarshal`.
+	Get(dest any) error
+
+	// Meta returns metadata (source name, revision) for this
+	// particular value.
+	Meta() meta.Info
+}


### PR DESCRIPTION
Introduce the tree API and Value APIs for safely storing configuration data.
Added various interfaces needed later.

* Extracted common types (KeyPath, SourceInfo, RevisionType, etc.) into a
separate packages.
* Implement the internal tree value layer for configuration tree operations.
* Removed some linters (make uniform configuration with other projects).
* Fix coverage problem in CI for golang 1.25 (https://github.com/golang/go/issues/75031).
* Fixed coverage (previously ignores everything without root files).
* Added more tests to increase coverage in different packages.

Closes TNTP-5716