### PR TITLE
collectors: surface YAML parse errors in Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `DefaultSchemaURL`.
 * Embed gzipped minified schemas for Tarantool 3.3.0 – 3.7.0, decompressed at
   package init.
+* `collectors.Storage.WithSkipInvalid(bool)` to silently skip documents that
+  failed to parse.
 
 ### Changed
 
@@ -27,8 +29,16 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   of fetching `https://download.tarantool.org/tarantool/schema/config.schema.json`
   at `Build()` time. This is a breaking change in default behavior.
 * Schema selectors on `tarantool.Builder` are now mutually exclusive.
+* `collectors.Storage.Collectors` is now strict by default: a document whose
+  value fails to parse causes `Collectors` to return an error wrapping
+  `ErrFormatParse` that identifies the offending storage key, instead of
+  being silently dropped.
 
 ### Fixed
+
+* `collectors.Storage` no longer silently skips documents with invalid YAML,
+  which could mask partially-loaded configurations
+  ([#26](https://github.com/tarantool/go-config/issues/26)).
 
 ## [v1.0.0] - 2026-03-10
 

--- a/collectors/directory.go
+++ b/collectors/directory.go
@@ -216,7 +216,7 @@ func (d *Directory) collectFiles(dirPath string) ([]config.Collector, error) {
 			continue
 		}
 
-		subtree, err := d.parseData(data)
+		subtree, err := d.parseData(filePath, data)
 		if err != nil {
 			return nil, err
 		}
@@ -237,14 +237,15 @@ func (d *Directory) collectFiles(dirPath string) ([]config.Collector, error) {
 	return docs, nil
 }
 
-// parseData parses raw bytes using the collector's format.
-func (d *Directory) parseData(data []byte) (*tree.Node, error) {
+// parseData parses raw bytes using the collector's format. filePath is
+// embedded into any FormatParseError so the caller can locate the file.
+func (d *Directory) parseData(filePath string, data []byte) (*tree.Node, error) {
 	reader := strings.NewReader(string(data))
 	format := d.format.From(reader)
 
 	node, err := format.Parse()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrFormatParse, err)
+		return nil, NewFormatParseError(filePath, err)
 	}
 
 	return node, nil

--- a/collectors/directory_test.go
+++ b/collectors/directory_test.go
@@ -176,7 +176,11 @@ func TestDirectory_Collectors_ParseError(t *testing.T) {
 	_, err := collector.Collectors(ctx)
 
 	require.Error(t, err)
-	assert.ErrorIs(t, err, collectors.ErrFormatParse)
+
+	var fpErr *collectors.FormatParseError
+
+	require.ErrorAs(t, err, &fpErr)
+	assert.Contains(t, fpErr.Key, "invalid.yaml")
 }
 
 func TestDirectory_Collectors_SkipsEmptyFiles(t *testing.T) {

--- a/collectors/errors.go
+++ b/collectors/errors.go
@@ -1,6 +1,9 @@
 package collectors
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrNoData indicates that there is no data to process.
@@ -13,8 +16,6 @@ var (
 	ErrReader = errors.New("reader processing error")
 	// ErrFetchStream indicates that fetching the stream failed.
 	ErrFetchStream = errors.New("failed to fetch the stream")
-	// ErrFormatParse indicates that parsing data with format failed.
-	ErrFormatParse = errors.New("failed to parse data with format")
 	// ErrStorageFetch indicates that storage fetch failed.
 	ErrStorageFetch = errors.New("storage fetch failed")
 	// ErrStorageKeyNotFound indicates that a storage key was not found.
@@ -26,3 +27,28 @@ var (
 	// ErrDirectoryRead indicates that reading a directory failed.
 	ErrDirectoryRead = errors.New("directory read failed")
 )
+
+// FormatParseError indicates that parsing a configuration value with the
+// configured format failed. Key identifies the offending source (storage key,
+// file path, etc.) and Err is the underlying parser error. Callers can match
+// it with errors.As(&FormatParseError{}) and inspect Err directly.
+type FormatParseError struct {
+	Key string
+	Err error
+}
+
+// NewFormatParseError builds a FormatParseError for the given source key and
+// underlying parser error.
+func NewFormatParseError(key string, err error) *FormatParseError {
+	return &FormatParseError{Key: key, Err: err}
+}
+
+// Error renders the full message including the key and the wrapped error.
+func (e *FormatParseError) Error() string {
+	return fmt.Sprintf("failed to parse data with format: key %q: %v", e.Key, e.Err)
+}
+
+// Unwrap exposes the underlying parser error so errors.Is/As can reach it.
+func (e *FormatParseError) Unwrap() error {
+	return e.Err
+}

--- a/collectors/errors_test.go
+++ b/collectors/errors_test.go
@@ -1,0 +1,38 @@
+package collectors_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config/collectors"
+)
+
+var errFormatParseTestSentinel = errors.New("unexpected token")
+
+func TestFormatParseError(t *testing.T) {
+	t.Parallel()
+
+	err := collectors.NewFormatParseError("/config/invalid", errFormatParseTestSentinel)
+
+	require.NotNil(t, err)
+	assert.Equal(t, "/config/invalid", err.Key)
+	assert.Same(t, errFormatParseTestSentinel, err.Err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "failed to parse data with format")
+	assert.Contains(t, msg, `"/config/invalid"`)
+	assert.Contains(t, msg, "unexpected token")
+
+	require.ErrorIs(t, err, errFormatParseTestSentinel)
+	assert.Same(t, errFormatParseTestSentinel, errors.Unwrap(err))
+
+	wrapped := error(err)
+
+	var fpErr *collectors.FormatParseError
+
+	require.ErrorAs(t, wrapped, &fpErr)
+	assert.Equal(t, "/config/invalid", fpErr.Key)
+}

--- a/collectors/source.go
+++ b/collectors/source.go
@@ -83,7 +83,7 @@ func NewSource(ctx context.Context, source DataSource, format Format) (config.Co
 
 	node, err := format.Parse()
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrFormatParse, err)
+		return nil, NewFormatParseError(source.Name(), err)
 	}
 
 	return &Source{

--- a/collectors/storage.go
+++ b/collectors/storage.go
@@ -17,14 +17,15 @@ import (
 // and merged into a single config tree. Key names are used only for
 // distinguishing documents; the YAML content determines the tree structure.
 type Storage struct {
-	name       string
-	sourceType config.SourceType
-	revision   config.RevisionType
-	keepOrder  bool
-	typed      *integrity.Typed[[]byte]
-	format     Format
-	prefix     string
-	delimiter  string
+	name        string
+	sourceType  config.SourceType
+	revision    config.RevisionType
+	keepOrder   bool
+	skipInvalid bool
+	typed       *integrity.Typed[[]byte]
+	format      Format
+	prefix      string
+	delimiter   string
 }
 
 // NewStorage creates a new Storage collector that reads all keys under the
@@ -36,14 +37,15 @@ func NewStorage(
 	format Format,
 ) *Storage {
 	return &Storage{
-		name:       "storage",
-		sourceType: config.StorageSource,
-		revision:   "",
-		keepOrder:  false,
-		typed:      typed,
-		format:     format,
-		prefix:     prefix,
-		delimiter:  "/",
+		name:        "storage",
+		sourceType:  config.StorageSource,
+		revision:    "",
+		keepOrder:   false,
+		skipInvalid: false,
+		typed:       typed,
+		format:      format,
+		prefix:      prefix,
+		delimiter:   "/",
 	}
 }
 
@@ -79,6 +81,16 @@ func (s *Storage) WithKeepOrder(keep bool) *Storage {
 	return s
 }
 
+// WithSkipInvalid sets whether Collectors should silently skip documents
+// whose value fails to parse. Default is false: a parse error on any key
+// causes Collectors to return a *FormatParseError identifying the offending
+// key. Enable this for tolerant reads where a single bad document should
+// not prevent loading the rest.
+func (s *Storage) WithSkipInvalid(skip bool) *Storage {
+	s.skipInvalid = skip
+	return s
+}
+
 // WithDelimiter sets the delimiter used to split storage keys into
 // config path segments. The default is "/". If the delimiter differs
 // from "/", it is replaced internally with "/" before constructing
@@ -108,6 +120,12 @@ func (s *Storage) KeepOrder() bool {
 	return s.keepOrder
 }
 
+// SkipInvalid returns whether documents with parse errors are skipped
+// silently instead of producing an error.
+func (s *Storage) SkipInvalid() bool {
+	return s.skipInvalid
+}
+
 // Collectors implements config.MultiCollector. It performs a range query with
 // the configured prefix, validates integrity, parses each key's value using the
 // collector's Format, and returns one sub-collector per storage key. Each
@@ -115,7 +133,10 @@ func (s *Storage) KeepOrder() bool {
 // MergerContext, source name, and revision.
 // The parent Storage's revision is updated to the maximum ModRevision among
 // the fetched keys.
-// Keys with empty values or parsing errors are skipped.
+// Keys with empty values are skipped. By default, a parse error on any key
+// causes Collectors to return a *FormatParseError that identifies the
+// offending key; use WithSkipInvalid(true) to silently skip invalid
+// documents instead.
 func (s *Storage) Collectors(ctx context.Context) ([]config.Collector, error) {
 	results, err := s.typed.Range(ctx, "",
 		integrity.IgnoreVerificationError())
@@ -150,7 +171,11 @@ func (s *Storage) Collectors(ctx context.Context) ([]config.Collector, error) {
 
 		subtree, parseErr := format.Parse()
 		if parseErr != nil {
-			continue
+			if s.skipInvalid {
+				continue
+			}
+
+			return nil, NewFormatParseError(s.prefix+result.Name, parseErr)
 		}
 
 		docName := s.sourceName(result.Name)

--- a/collectors/storage_source_test.go
+++ b/collectors/storage_source_test.go
@@ -220,5 +220,8 @@ func TestStorageSource_WithSource_InvalidYaml(t *testing.T) {
 
 	_, err := collectors.NewSource(t.Context(), source, collectors.NewYamlFormat())
 	require.Error(t, err)
-	assert.ErrorIs(t, err, collectors.ErrFormatParse)
+
+	var fpErr *collectors.FormatParseError
+
+	require.ErrorAs(t, err, &fpErr)
 }

--- a/collectors/storage_test.go
+++ b/collectors/storage_test.go
@@ -2,6 +2,7 @@ package collectors_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -261,7 +262,7 @@ func TestStorage_Read_RangeError(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
-func TestStorage_Read_InvalidYamlValue(t *testing.T) {
+func TestStorage_Collectors_InvalidYamlValue_Strict(t *testing.T) {
 	t.Parallel()
 
 	mock := testutil.NewMockStorage()
@@ -270,6 +271,63 @@ func TestStorage_Read_InvalidYamlValue(t *testing.T) {
 
 	typed := testutil.NewRawTyped(mock, "/config/")
 	collector := collectors.NewStorage(typed, "/config/", collectors.NewYamlFormat())
+
+	assert.False(t, collector.SkipInvalid())
+
+	subs, err := collector.Collectors(context.Background())
+
+	var fpErr *collectors.FormatParseError
+
+	require.ErrorAs(t, err, &fpErr)
+	assert.Equal(t, "/config/invalid", fpErr.Key)
+	assert.Nil(t, subs)
+}
+
+func TestStorage_Builder_InvalidYamlValue_Strict(t *testing.T) {
+	t.Parallel()
+
+	mock := testutil.NewMockStorage()
+	testutil.PutIntegrity(mock, "/config/", "invalid", []byte("bad: yaml: [unclosed"))
+	testutil.PutIntegrity(mock, "/config/", "valid", []byte("mykey: value"))
+
+	typed := testutil.NewRawTyped(mock, "/config/")
+	collector := collectors.NewStorage(typed, "/config/", collectors.NewYamlFormat())
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collector)
+
+	_, errs := builder.Build(t.Context())
+	require.NotEmpty(t, errs)
+
+	var fpErr *collectors.FormatParseError
+
+	var matched bool
+
+	for _, e := range errs {
+		if errors.As(e, &fpErr) {
+			matched = true
+
+			break
+		}
+	}
+
+	require.True(t, matched, "expected *FormatParseError among builder errors: %v", errs)
+	assert.Equal(t, "/config/invalid", fpErr.Key)
+}
+
+func TestStorage_Read_InvalidYamlValue_SkipInvalid(t *testing.T) {
+	t.Parallel()
+
+	mock := testutil.NewMockStorage()
+	testutil.PutIntegrity(mock, "/config/", "invalid", []byte("bad: yaml: [unclosed"))
+	testutil.PutIntegrity(mock, "/config/", "valid", []byte("mykey: value"))
+
+	typed := testutil.NewRawTyped(mock, "/config/")
+	collector := collectors.NewStorage(typed, "/config/", collectors.NewYamlFormat()).
+		WithSkipInvalid(true)
+
+	assert.True(t, collector.SkipInvalid())
 
 	ctx := context.Background()
 	channel := collector.Read(ctx)


### PR DESCRIPTION
Storage.Collectors silently ignores parse errors, matching none of the other collectors and making partial loads undiagnosable. Parse failures now return an error wrapping ErrFormatParse that identifies the offending storage key. Ignoring errors is still possible.

Closes #26