### PR TITLE
tarantool: add WithEnvIgnore for shell-glob env-var filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   package init.
 * `collectors.Storage.WithSkipInvalid(bool)` to silently skip documents that
   failed to parse.
+* `tarantool.Builder.WithEnvIgnore(patterns ...string)` shell-glob patterns
+  for env-var names to drop before the env transform runs.
 
 ### Changed
 

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 
 	config "github.com/tarantool/go-config"
@@ -13,8 +14,10 @@ import (
 	"github.com/tarantool/go-storage/integrity"
 )
 
-const defaultEnvPrefix = "TT_"
-const defaultEnvSuffix = "_DEFAULT"
+const (
+	defaultEnvPrefix = "TT_"
+	defaultEnvSuffix = "_DEFAULT"
+)
 
 // DefaultStorageKey is the middle path segment that Tarantool uses between the
 // storage base prefix and the configuration keys. The full storage path is
@@ -29,6 +32,7 @@ type Builder struct {
 	configFile string
 	configDir  string
 	envPrefix  string
+	envIgnore  []string
 
 	storage    *integrity.Typed[[]byte]
 	storageKey string
@@ -93,6 +97,18 @@ func (b *Builder) WithStorageKey(key string) *Builder {
 // WithEnvPrefix sets the environment variable prefix (default "TT_").
 func (b *Builder) WithEnvPrefix(prefix string) *Builder {
 	b.envPrefix = prefix
+	return b
+}
+
+// WithEnvIgnore registers shell-glob patterns ([path.Match] syntax)
+// against which incoming env-var names are checked. Matched names are
+// dropped before the env transform runs. Patterns are matched against
+// the full env-var name including the configured prefix (e.g.
+// "TT_CLI_*", not "CLI_*"). Multiple calls append; patterns are
+// validated at [Builder.Build] time and an invalid one surfaces as
+// [ErrBadEnvIgnorePattern].
+func (b *Builder) WithEnvIgnore(patterns ...string) *Builder {
+	b.envIgnore = append(b.envIgnore, patterns...)
 	return b
 }
 
@@ -297,6 +313,27 @@ func keyPathFromdKey(key string) config.KeyPath {
 	return config.NewKeyPathFromSegments(filtered)
 }
 
+func envFilter(
+	prefix string,
+	patterns []string,
+	next func(string) config.KeyPath,
+) func(string) config.KeyPath {
+	if len(patterns) == 0 {
+		return next
+	}
+
+	return func(key string) config.KeyPath {
+		full := prefix + key
+		for _, pat := range patterns {
+			if ok, _ := path.Match(pat, full); ok {
+				return nil
+			}
+		}
+
+		return next(key)
+	}
+}
+
 // regularEnvTransform returns a transform function for the regular env
 // collector. It skips variables ending with "_DEFAULT" (those belong to the
 // default-env collector), lowercases the remainder, and splits by "_".
@@ -340,13 +377,20 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 		return config.Builder{}, err
 	}
 
+	for _, pat := range b.envIgnore {
+		_, matchErr := path.Match(pat, "")
+		if matchErr != nil {
+			return config.Builder{}, fmt.Errorf("%w %q: %w", ErrBadEnvIgnorePattern, pat, matchErr)
+		}
+	}
+
 	inner := config.NewBuilder()
 
 	// 1. Default env vars (lowest priority).
 	inner = inner.AddCollector(
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(defaultEnvTransform(b.envPrefix)).
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, defaultEnvTransform(b.envPrefix))).
 			WithName("env-default").
 			WithSourceType(config.EnvDefaultSource),
 	)
@@ -380,7 +424,7 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 	inner = inner.AddCollector(
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(regularEnvTransform()).
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, regularEnvTransform())).
 			WithName("env").
 			WithSourceType(config.EnvSource),
 	)

--- a/tarantool/builder_envignore_test.go
+++ b/tarantool/builder_envignore_test.go
@@ -1,0 +1,165 @@
+package tarantool_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/tarantool"
+)
+
+func TestBuild_EnvIgnore_ExactMatch(t *testing.T) {
+	t.Setenv("TT_FOO", "x")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_FOO").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("foo"))
+	assert.False(t, ok, "exact-name ignore should drop the var")
+}
+
+func TestBuild_EnvIgnore_GlobMatch(t *testing.T) {
+	t.Setenv("TT_CLI_REPO_ROCKS", "x")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_CLI_*").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("cli/repo/rocks"))
+	assert.False(t, ok, "glob ignore should drop matching vars")
+}
+
+func TestBuild_EnvIgnore_AppliesToDefaultSuffix(t *testing.T) {
+	t.Setenv("TT_FOO_DEFAULT", "x")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_FOO_DEFAULT").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("foo"))
+	assert.False(t, ok, "ignore should also filter _DEFAULT vars")
+}
+
+func TestBuild_EnvIgnore_MultiplePatterns(t *testing.T) {
+	t.Setenv("TT_A", "1")
+	t.Setenv("TT_B_INNER", "2")
+	t.Setenv("TT_C", "3")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_A", "TT_B_*").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("a"))
+	assert.False(t, ok, "TT_A ignored")
+
+	_, ok = cfg.Lookup(config.NewKeyPath("b/inner"))
+	assert.False(t, ok, "TT_B_INNER ignored")
+
+	var c string
+
+	_, err = cfg.Get(config.NewKeyPath("c"), &c)
+	require.NoError(t, err)
+	assert.Equal(t, "3", c, "TT_C survives")
+}
+
+func TestBuild_EnvIgnore_AccumulatesAcrossCalls(t *testing.T) {
+	t.Setenv("TT_A", "1")
+	t.Setenv("TT_B", "2")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_A").
+		WithEnvIgnore("TT_B").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("a"))
+	assert.False(t, ok)
+
+	_, ok = cfg.Lookup(config.NewKeyPath("b"))
+	assert.False(t, ok)
+}
+
+func TestBuild_EnvIgnore_BadPattern(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	_, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_[").
+		Build(ctx)
+	require.ErrorIs(t, err, tarantool.ErrBadEnvIgnorePattern)
+}
+
+func TestBuild_EnvIgnore_EmptyIsNoOp(t *testing.T) {
+	t.Setenv("TT_FOO", "value")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		Build(ctx)
+	require.NoError(t, err)
+
+	var foo string
+
+	_, err = cfg.Get(config.NewKeyPath("foo"), &foo)
+	require.NoError(t, err)
+	assert.Equal(t, "value", foo, "no ignore patterns ⇒ unchanged behaviour")
+}
+
+// TestBuild_EnvIgnore_TTCLIPollution checks that WithEnvIgnore("TT_CLI_*")
+// drops tt-CLI env vars from the config tree while leaving other TT_* vars intact.
+func TestBuild_EnvIgnore_TTCLIPollution(t *testing.T) {
+	t.Setenv("TT_CLI_REPO_ROCKS", "/sdk/rocks")
+	t.Setenv("TT_CLI_TARANTOOL_PREFIX", "/sdk/3.5.0")
+	t.Setenv("TT_USER_FIELD", "expected-value")
+
+	ctx := context.Background()
+
+	dirty, err := tarantool.New().
+		WithoutSchema().
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, polluted := dirty.Lookup(config.NewKeyPath("cli/repo/rocks"))
+	assert.True(t, polluted, "baseline: TT_CLI_REPO_ROCKS leaks into the tree without an ignore list")
+
+	clean, err := tarantool.New().
+		WithoutSchema().
+		WithEnvIgnore("TT_CLI_*").
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, polluted = clean.Lookup(config.NewKeyPath("cli/repo/rocks"))
+	assert.False(t, polluted, "TT_CLI_* should be gone after WithEnvIgnore")
+
+	var userField string
+
+	_, err = clean.Get(config.NewKeyPath("user/field"), &userField)
+	require.NoError(t, err)
+	assert.Equal(t, "expected-value", userField, "unrelated TT_* vars survive")
+}

--- a/tarantool/doc.go
+++ b/tarantool/doc.go
@@ -13,6 +13,16 @@
 //  3. Centralized storage (etcd / tarantool-storage) under <prefix>/config/*.
 //  4. Environment variables — TT_* prefix.
 //
+// # Ignoring environment variables
+//
+// [Builder.WithEnvIgnore] takes shell-glob patterns ([path.Match]
+// syntax) that drop matching env vars before the env transform runs.
+// Patterns are matched against the full env-var name, so use the same
+// string you'd see in `env | grep TT_` — for example,
+// WithEnvIgnore("TT_CLI_*") to skip the variables the tt CLI exports
+// into developer shells. Invalid patterns surface as
+// [ErrBadEnvIgnorePattern] from [Builder.Build].
+//
 // # Inheritance
 //
 // The builder registers the Tarantool hierarchy

--- a/tarantool/errors.go
+++ b/tarantool/errors.go
@@ -23,4 +23,8 @@ var (
 	// ErrConflictingSchemaOptions is returned when mutually exclusive schema
 	// options are set on the same Builder.
 	ErrConflictingSchemaOptions = errors.New("tarantool: conflicting schema options")
+
+	// ErrBadEnvIgnorePattern is returned when [Builder.WithEnvIgnore]
+	// receives a pattern that path.Match rejects.
+	ErrBadEnvIgnorePattern = errors.New("tarantool: invalid env-ignore pattern")
 )


### PR DESCRIPTION
WithEnvIgnore(patterns ...string) drops env vars by path.Match-style patterns before the env transform runs.

Related to TNTP-7385