### PR TITLE
tarantool: derive env-var paths from JSON schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   so YAML sequences are correctly represented as arrays after inheritance
   resolution
   ([#34](https://github.com/tarantool/go-config/issues/34)).
+* env vars with compound schema keys (e.g. `TT_AUDIT_LOG_NONBLOCK`,
+  `TT_WAL_QUEUE_MAX_SIZE`, `TT_REPLICATION_FAILOVER`) now resolve to the
+  correct config path when a JSON schema is supplied.
+
 
 ## [v1.0.0] - 2026-03-10
 

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -11,6 +11,7 @@ import (
 
 	config "github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/tarantool/internal/envpath"
 	"github.com/tarantool/go-storage/integrity"
 )
 
@@ -331,10 +332,19 @@ func envFilter(
 	}
 }
 
+func resolvePath(resolver *envpath.Node, key string) config.KeyPath {
+	if resolver != nil {
+		return resolver.Resolve(key)
+	}
+
+	return keyPathFromdKey(key)
+}
+
 // regularEnvTransform returns a transform function for the regular env
 // collector. It skips variables ending with "_DEFAULT" (those belong to the
-// default-env collector), lowercases the remainder, and splits by "_".
-func regularEnvTransform() func(string) config.KeyPath {
+// default-env collector) and resolves the remainder via the schema trie
+// when available, otherwise via naive underscore split.
+func regularEnvTransform(resolver *envpath.Node) func(string) config.KeyPath {
 	suffix := defaultEnvSuffix
 
 	return func(key string) config.KeyPath {
@@ -342,14 +352,15 @@ func regularEnvTransform() func(string) config.KeyPath {
 			return nil
 		}
 
-		return keyPathFromdKey(key)
+		return resolvePath(resolver, key)
 	}
 }
 
 // defaultEnvTransform returns a transform function for the default-env
 // collector. It filters for variables ending with "_DEFAULT", strips that
-// suffix, lowercases the remainder, and splits by "_" into a key path.
-func defaultEnvTransform(_ string) func(string) config.KeyPath {
+// suffix, and resolves the remainder via the schema trie when available,
+// otherwise via naive underscore split.
+func defaultEnvTransform(resolver *envpath.Node) func(string) config.KeyPath {
 	suffix := defaultEnvSuffix
 
 	return func(key string) config.KeyPath {
@@ -362,7 +373,7 @@ func defaultEnvTransform(_ string) func(string) config.KeyPath {
 			return nil
 		}
 
-		return keyPathFromdKey(key)
+		return resolvePath(resolver, key)
 	}
 }
 
@@ -381,13 +392,31 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 		}
 	}
 
+	// Resolve the schema once: env transforms need the resolver, schema
+	// validation needs the raw bytes.
+	var (
+		schemaBytes []byte
+		resolver    *envpath.Node
+	)
+
+	if !b.skipSchema {
+		schemaBytes, err = b.resolveSchema(ctx)
+		if err != nil {
+			return config.Builder{}, err
+		}
+
+		// Malformed schemas surface via WithJSONSchema below; a nil resolver
+		// falls back to the naive underscore split.
+		resolver, _ = envpath.Build(schemaBytes)
+	}
+
 	inner := config.NewBuilder()
 
 	// 1. Default env vars (lowest priority).
 	inner = inner.AddCollector(
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(envFilter(b.envPrefix, b.envIgnore, defaultEnvTransform(b.envPrefix))).
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, defaultEnvTransform(resolver))).
 			WithName("env-default").
 			WithSourceType(config.EnvDefaultSource),
 	)
@@ -421,19 +450,14 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 	inner = inner.AddCollector(
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(envFilter(b.envPrefix, b.envIgnore, regularEnvTransform())).
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, regularEnvTransform(resolver))).
 			WithName("env").
 			WithSourceType(config.EnvSource),
 	)
 
 	// 5. Schema validation.
 	if !b.skipSchema {
-		schema, schemaErr := b.resolveSchema(ctx)
-		if schemaErr != nil {
-			return config.Builder{}, schemaErr
-		}
-
-		inner, err = inner.WithJSONSchema(bytes.NewReader(schema))
+		inner, err = inner.WithJSONSchema(bytes.NewReader(schemaBytes))
 		if err != nil {
 			return config.Builder{}, fmt.Errorf("json schema: %w", err)
 		}

--- a/tarantool/builder_envschema_test.go
+++ b/tarantool/builder_envschema_test.go
@@ -1,0 +1,158 @@
+package tarantool_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/tarantool"
+)
+
+const fixtureSchemaPath = "testdata/config.schema.json"
+
+func TestBuild_Env_SchemaAware_AuditLog(t *testing.T) {
+	t.Setenv("TT_AUDIT_LOG_NONBLOCK", "true")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var nonblock string
+
+	_, err = cfg.Get(config.NewKeyPath("audit_log/nonblock"), &nonblock)
+	require.NoError(t, err)
+	assert.Equal(t, "true", nonblock)
+}
+
+func TestBuild_Env_SchemaAware_WalQueueMaxSize(t *testing.T) {
+	t.Setenv("TT_WAL_QUEUE_MAX_SIZE", "123")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var size string
+
+	_, err = cfg.Get(config.NewKeyPath("wal_queue_max_size"), &size)
+	require.NoError(t, err)
+	assert.Equal(t, "123", size)
+}
+
+func TestBuild_Env_SchemaAware_ReplicationFailover(t *testing.T) {
+	t.Setenv("TT_REPLICATION_FAILOVER", "manual")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = cfg.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", failover)
+}
+
+func TestBuild_Env_SchemaAware_IprotoListen(t *testing.T) {
+	t.Setenv("TT_IPROTO_LISTEN", "3301")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var listen string
+
+	_, err = cfg.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	assert.Equal(t, "3301", listen)
+}
+
+func TestBuild_Env_SchemaAware_UnknownSkipped(t *testing.T) {
+	t.Setenv("TT_UNKNOWN_THING", "x")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("unknown/thing"))
+	assert.False(t, ok, "unknown env var should not be applied")
+
+	_, ok = cfg.Lookup(config.NewKeyPath("unknown_thing"))
+	assert.False(t, ok, "unknown env var should not be applied as a single segment either")
+}
+
+func TestBuild_Env_SchemaAware_DefaultSuffix(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, cfgPath, "audit_log:\n  nonblock: from-file\n")
+
+	t.Setenv("TT_AUDIT_LOG_NONBLOCK_DEFAULT", "from-default-env")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var nonblock string
+
+	_, err = cfg.Get(config.NewKeyPath("audit_log/nonblock"), &nonblock)
+	require.NoError(t, err)
+	assert.Equal(t, "from-file", nonblock, "file should override default-env")
+}
+
+func TestBuild_Env_NoSchema_HeuristicUnchanged(t *testing.T) {
+	t.Setenv("TT_AUDIT_LOG_NONBLOCK", "true")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithoutSchema().
+		Build(ctx)
+	require.NoError(t, err)
+
+	var nonblock string
+
+	_, err = cfg.Get(config.NewKeyPath("audit/log/nonblock"), &nonblock)
+	require.NoError(t, err)
+	assert.Equal(t, "true", nonblock,
+		"without schema, naive split sends the value to the wrong path")
+}
+
+func TestBuild_Env_SchemaAware_Wildcard(t *testing.T) {
+	t.Setenv("TT_GROUPS_FOO_REPLICASETS_BAR_INSTANCES_BAZ_IPROTO_LISTEN", "3302")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var listen string
+
+	_, err = cfg.Get(config.NewKeyPath(
+		"groups/foo/replicasets/bar/instances/baz/iproto/listen"), &listen)
+	require.NoError(t, err)
+	assert.Equal(t, "3302", listen)
+}

--- a/tarantool/doc.go
+++ b/tarantool/doc.go
@@ -23,6 +23,29 @@
 // into developer shells. Invalid patterns surface as
 // [ErrBadEnvIgnorePattern] from [Builder.Build].
 //
+// # Environment variable path resolution
+//
+// When a JSON schema is supplied (via [Builder.WithSchema] or
+// [Builder.WithSchemaFile], or fetched at build time), env-var names
+// are resolved to config key paths by walking the schema with greedy
+// longest-prefix matching. This lets compound keys like
+// TT_AUDIT_LOG_NONBLOCK reach audit_log.nonblock and
+// TT_WAL_QUEUE_MAX_SIZE reach wal_queue_max_size, instead of being
+// naively split into "audit/log/nonblock" or "wal/queue/max/size".
+//
+// Vars that don't match any schema path are silently dropped. With
+// [Builder.WithoutSchema] the legacy underscore-split is used.
+//
+// Wildcard segments (e.g. group / replicaset / instance names under
+// additionalProperties) consume exactly one underscore-separated token
+// each; user-defined names containing '_' (e.g. "my_group") are not
+// supported and will fail to resolve.
+//
+// Schema features the resolver does not understand — allOf / oneOf /
+// anyOf composition, $ref pointing anywhere other than #/$defs/<name>
+// or #/definitions/<name> — are treated as opaque and any paths
+// buried beneath them won't be reachable via env vars.
+//
 // # Inheritance
 //
 // The builder registers the Tarantool hierarchy

--- a/tarantool/internal/envpath/envpath.go
+++ b/tarantool/internal/envpath/envpath.go
@@ -1,0 +1,214 @@
+// Package envpath builds a trie of property paths from a Tarantool JSON
+// schema and resolves stripped environment-variable keys against it via
+// greedy longest-prefix matching.
+package envpath
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/tarantool/go-config"
+)
+
+// Node is a trie node keyed by lowercased schema segment names.
+// wildcard is set when the schema permits arbitrary names at this level.
+type Node struct {
+	children map[string]*Node
+	wildcard *Node
+}
+
+// Build parses a JSON schema and returns a trie of property paths.
+func Build(schema []byte) (*Node, error) {
+	var root map[string]any
+
+	err := json.Unmarshal(schema, &root)
+	if err != nil {
+		return nil, fmt.Errorf("envpath: parse schema: %w", err)
+	}
+
+	defs := extractDefs(root)
+	node := newNode()
+
+	walkSchemaNode(node, root, defs, map[string]bool{})
+
+	return node, nil
+}
+
+func newNode() *Node {
+	return &Node{
+		children: map[string]*Node{},
+		wildcard: nil,
+	}
+}
+
+func extractDefs(root map[string]any) map[string]any {
+	for _, key := range []string{"$defs", "definitions"} {
+		raw, ok := root[key].(map[string]any)
+		if ok {
+			return raw
+		}
+	}
+
+	return map[string]any{}
+}
+
+// walkSchemaNode populates parent with children for every property reachable
+// beneath node. visited guards against self-referential $refs.
+func walkSchemaNode(parent *Node, node map[string]any, defs map[string]any, visited map[string]bool) {
+	var marked []string
+
+	defer func() {
+		for _, name := range marked {
+			delete(visited, name)
+		}
+	}()
+
+	for {
+		ref, hasRef := node["$ref"].(string)
+		if !hasRef {
+			break
+		}
+
+		name, ok := localRefName(ref)
+		if !ok || visited[name] {
+			return
+		}
+
+		target, ok := defs[name].(map[string]any)
+		if !ok {
+			return
+		}
+
+		visited[name] = true
+
+		marked = append(marked, name)
+		node = target
+	}
+
+	props, ok := node["properties"].(map[string]any)
+	if ok {
+		for name, raw := range props {
+			child, isObj := raw.(map[string]any)
+			if !isObj {
+				continue
+			}
+
+			childNode := newNode()
+
+			parent.children[strings.ToLower(name)] = childNode
+
+			walkSchemaNode(childNode, child, defs, visited)
+		}
+	}
+
+	if hasWildcardChildren(node) {
+		parent.wildcard = newNode()
+
+		additional, isObj := node["additionalProperties"].(map[string]any)
+		if isObj {
+			walkSchemaNode(parent.wildcard, additional, defs, visited)
+		}
+
+		// Multiple patternProperties merge into the single wildcard node —
+		// last writer wins on overlapping property names.
+		patterns, isObj := node["patternProperties"].(map[string]any)
+		if isObj {
+			for _, raw := range patterns {
+				schema, isObj := raw.(map[string]any)
+				if !isObj {
+					continue
+				}
+
+				walkSchemaNode(parent.wildcard, schema, defs, visited)
+			}
+		}
+	}
+}
+
+func hasWildcardChildren(node map[string]any) bool {
+	additional, present := node["additionalProperties"]
+	if present {
+		if b, isBool := additional.(bool); isBool && b {
+			return true
+		}
+
+		if _, isObj := additional.(map[string]any); isObj {
+			return true
+		}
+	}
+
+	patterns, isObj := node["patternProperties"].(map[string]any)
+	if isObj && len(patterns) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// localRefName extracts the definition name from a $ref into $defs or
+// definitions; other $ref shapes return ok=false.
+func localRefName(ref string) (string, bool) {
+	name, ok := strings.CutPrefix(ref, "#/$defs/")
+	if ok {
+		return name, true
+	}
+
+	return strings.CutPrefix(ref, "#/definitions/")
+}
+
+// Resolve maps a stripped env-var key to a config.KeyPath via greedy
+// longest-prefix matching against the schema trie. Returns nil on no match.
+func (n *Node) Resolve(key string) config.KeyPath {
+	if key == "" {
+		return nil
+	}
+
+	parts := strings.Split(strings.ToLower(key), "_")
+
+	tokens := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p != "" {
+			tokens = append(tokens, p)
+		}
+	}
+
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	return resolveTokens(n, tokens)
+}
+
+func resolveTokens(node *Node, tokens []string) config.KeyPath {
+	if len(tokens) == 0 {
+		return config.KeyPath{}
+	}
+
+	for take := len(tokens); take >= 1; take-- {
+		segment := strings.Join(tokens[:take], "_")
+
+		child, ok := node.children[segment]
+		if !ok {
+			continue
+		}
+
+		tail := resolveTokens(child, tokens[take:])
+		if tail == nil {
+			continue
+		}
+
+		return append(config.KeyPath{segment}, tail...)
+	}
+
+	if node.wildcard != nil {
+		tail := resolveTokens(node.wildcard, tokens[1:])
+		if tail == nil {
+			return nil
+		}
+
+		return append(config.KeyPath{tokens[0]}, tail...)
+	}
+
+	return nil
+}

--- a/tarantool/internal/envpath/envpath_test.go
+++ b/tarantool/internal/envpath/envpath_test.go
@@ -1,0 +1,154 @@
+package envpath_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/tarantool/internal/envpath"
+)
+
+func loadFixtureSchema(t *testing.T) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "config.schema.json"))
+	require.NoError(t, err)
+
+	return data
+}
+
+func TestTrie_SimpleKey(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	got := root.Resolve("REPLICATION_FAILOVER")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"replication", "failover"}), got)
+}
+
+func TestTrie_CompoundKey_AuditLog(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	got := root.Resolve("AUDIT_LOG_NONBLOCK")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"audit_log", "nonblock"}), got)
+}
+
+func TestTrie_CompoundKey_LongestWins(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	gotLong := root.Resolve("WAL_QUEUE_MAX_SIZE")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"wal_queue_max_size"}), gotLong)
+
+	gotShort := root.Resolve("WAL_DIR")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"wal", "dir"}), gotShort)
+}
+
+func TestTrie_Wildcard(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	got := root.Resolve("GROUPS_FOO_REPLICASETS_BAR_INSTANCES_BAZ_IPROTO_LISTEN")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{
+		"groups", "foo", "replicasets", "bar", "instances", "baz", "iproto", "listen",
+	}), got)
+}
+
+func TestTrie_Unknown(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	got := root.Resolve("UNKNOWN_THING")
+	assert.Nil(t, got)
+}
+
+func TestTrie_EmptyKey(t *testing.T) {
+	t.Parallel()
+
+	root, err := envpath.Build(loadFixtureSchema(t))
+	require.NoError(t, err)
+
+	got := root.Resolve("")
+	assert.Nil(t, got)
+}
+
+func TestTrie_MalformedSchema(t *testing.T) {
+	t.Parallel()
+
+	_, err := envpath.Build([]byte("not json"))
+	require.Error(t, err)
+}
+
+func TestTrie_RefCycle(t *testing.T) {
+	t.Parallel()
+
+	// $defs.node references itself via a nested property — the walker
+	// must not infinite-recurse.
+	schema := []byte(`{
+		"type": "object",
+		"$defs": {
+			"node": {
+				"properties": {
+					"child": { "$ref": "#/$defs/node" },
+					"leaf": { "type": "string" }
+				}
+			}
+		},
+		"properties": {
+			"root": { "$ref": "#/$defs/node" }
+		}
+	}`)
+
+	// Build must terminate (the cycle was previously a stack overflow
+	// at Build time).
+	root, err := envpath.Build(schema)
+	require.NoError(t, err)
+
+	// Properties siblings of the cyclic ref stay reachable.
+	got := root.Resolve("ROOT_LEAF")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"root", "leaf"}), got)
+
+	// Paths through the cycle are pruned at the first re-entry — the
+	// env var is silently dropped rather than expanded indefinitely.
+	got = root.Resolve("ROOT_CHILD_LEAF")
+	assert.Nil(t, got)
+}
+
+func TestTrie_Ref(t *testing.T) {
+	t.Parallel()
+
+	schema := []byte(`{
+		"type": "object",
+		"$defs": {
+			"netbox": {
+				"type": "object",
+				"properties": {
+					"listen": { "type": "string" }
+				}
+			}
+		},
+		"properties": {
+			"iproto": { "$ref": "#/$defs/netbox" }
+		}
+	}`)
+
+	root, err := envpath.Build(schema)
+	require.NoError(t, err)
+
+	got := root.Resolve("IPROTO_LISTEN")
+	assert.Equal(t, config.NewKeyPathFromSegments([]string{"iproto", "listen"}), got)
+}

--- a/tarantool/internal/envpath/testdata/config.schema.json
+++ b/tarantool/internal/envpath/testdata/config.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "audit_log": {
+      "type": "object",
+      "properties": {
+        "nonblock": { "type": "string" },
+        "file": { "type": "string" }
+      }
+    },
+    "wal": {
+      "type": "object",
+      "properties": {
+        "dir": { "type": "string" }
+      }
+    },
+    "wal_queue_max_size": { "type": "string" },
+    "replication": {
+      "type": "object",
+      "properties": {
+        "failover": { "type": "string" }
+      }
+    },
+    "iproto": {
+      "type": "object",
+      "properties": {
+        "listen": { "type": "string" }
+      }
+    },
+    "groups": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "replicasets": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "instances": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "iproto": {
+                        "type": "object",
+                        "properties": {
+                          "listen": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tarantool/testdata/config.schema.json
+++ b/tarantool/testdata/config.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "audit_log": {
+      "type": "object",
+      "properties": {
+        "nonblock": { "type": "string" },
+        "file": { "type": "string" }
+      }
+    },
+    "wal": {
+      "type": "object",
+      "properties": {
+        "dir": { "type": "string" }
+      }
+    },
+    "wal_queue_max_size": { "type": "string" },
+    "replication": {
+      "type": "object",
+      "properties": {
+        "failover": { "type": "string" }
+      }
+    },
+    "iproto": {
+      "type": "object",
+      "properties": {
+        "listen": { "type": "string" }
+      }
+    },
+    "groups": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "replicasets": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "instances": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "iproto": {
+                        "type": "object",
+                        "properties": {
+                          "listen": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The previous TT_* env-var transform split names on '_' and silently dropped any compound key the schema defines (audit_log, wal_queue_max_size, iproto.listen, …). With a JSON schema in hand the builder now walks the schema once into a trie and resolves env names by greedy longest-prefix match, falling back to the wildcard child for additionalProperties / patternProperties so groups/<name>/replicasets/<name>/… works.

Vars that don't match any schema path are silently dropped instead of written to unknown keys. Without a schema (WithoutSchema) the legacy naive split is preserved verbatim.

Related to TNTP-7385