### PR TITLE
collectors: preserve empty mapping nodes during parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * `collectors.Storage` no longer silently skips documents with invalid YAML,
   which could mask partially-loaded configurations
   ([#26](https://github.com/tarantool/go-config/issues/26)).
+* Fix empty YAML mappings (`{}`) being silently dropped during parsing,
+  which caused `EffectiveAll()` to miss leaf entities with empty configs
+  ([#32](https://github.com/tarantool/go-config/issues/32)).
 
 ## [v1.0.0] - 2026-03-10
 

--- a/collectors/tree_walk.go
+++ b/collectors/tree_walk.go
@@ -24,7 +24,11 @@ func flattenMapIntoTree(node *tree.Node, prefix config.KeyPath, m map[string]any
 
 		switch val := value.(type) {
 		case map[string]any:
-			flattenMapIntoTree(node, path, val, keepOrder)
+			if len(val) == 0 {
+				node.Set(path, map[string]any{})
+			} else {
+				flattenMapIntoTree(node, path, val, keepOrder)
+			}
 		default:
 			node.Set(path, value)
 		}

--- a/collectors/yaml.go
+++ b/collectors/yaml.go
@@ -86,6 +86,12 @@ func flattenYamlIntoTree(node *tree.Node, yamlNode yaml.Node,
 			flattenYamlIntoTree(node, *child, prefix)
 		}
 	case yaml.MappingNode:
+		if len(yamlNode.Content) == 0 {
+			node.Set(prefix, map[string]any{})
+
+			return
+		}
+
 		for i := 0; i < len(yamlNode.Content); i += 2 {
 			key := yamlNode.Content[i]
 			value := yamlNode.Content[i+1]

--- a/collectors/yaml_test.go
+++ b/collectors/yaml_test.go
@@ -63,6 +63,26 @@ func TestYaml_Parse(t *testing.T) {
 	assert.Equal(t, "default-cluster", val)
 }
 
+func TestYaml_Parse_EmptyMapping(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("groups:\n  storages:\n    replicasets:\n      r-001:\n        instances:\n          inst1: {}")
+
+	format := collectors.NewYamlFormat().From(bytes.NewReader(data))
+	require.NotNil(t, format)
+
+	root, err := format.Parse()
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	node := root.Get(config.NewKeyPath("groups/storages/replicasets/r-001/instances/inst1"))
+	require.NotNil(t, node)
+
+	val, ok := node.Value.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, val)
+}
+
 func TestYaml_Parse_Invalid(t *testing.T) {
 	t.Parallel()
 

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -827,6 +827,48 @@ func TestWithInheritance_EffectiveAllMultipleLeafs(t *testing.T) {
 	}
 }
 
+func TestWithInheritance_EffectiveAll_EmptyMappingLeaf(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"r-001": map[string]any{
+						"instances": map[string]any{
+							"inst1": map[string]any{},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+
+	all, err := cfg.EffectiveAll()
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	instanceCfg, ok := all["groups/storages/replicasets/r-001/instances/inst1"]
+	assert.True(t, ok)
+
+	var failover string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", failover)
+}
+
 func TestLevels_Panic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Empty YAML mappings (`{}`) and empty `map[string]any` values were silently dropped during parsing because the recursive flattening functions skipped nodes with no content. As a result, `Config.EffectiveAll()` never discovered leaf entities that had an empty config block, which is a valid pattern in Tarantool cluster configurations where an instance inherits everything from higher levels.

## Changes

- `collectors/yaml.go`: create a node with `map[string]any{}` when a `yaml.MappingNode` has no content.
- `collectors/tree_walk.go`: create a node with `map[string]any{}` when a `map[string]any` is empty.
- Added tests for both cases.

## Checklist

- [x] Tests added/updated
- [x] Changelog entry added
- [x] Well-written commit messages

Closes #32