### PR TITLE
config: preserve isArray flag when merging numeric children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Remove redundant `roles` merge strategy from `tarantool.Builder` defaults
   since `MergeReplace` is already the default inheritance behavior
   ([#34](https://github.com/tarantool/go-config/issues/34)).
+* Remove hardcoded `leader` exclusion from `tarantool.Builder` default
+  inheritance options so `leader` is now inherited down the hierarchy
+  like other keys. Users who need the old behavior can opt out via
+  `WithInheritanceOption(config.WithNoInherit("leader"))`
+  ([#36](https://github.com/tarantool/go-config/issues/36)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   value fails to parse causes `Collectors` to return an error wrapping
   `ErrFormatParse` that identifies the offending storage key, instead of
   being silently dropped.
+* Remove redundant `roles` merge strategy from `tarantool.Builder` defaults
+  since `MergeReplace` is already the default inheritance behavior
+  ([#34](https://github.com/tarantool/go-config/issues/34)).
 
 ### Fixed
 
@@ -44,6 +47,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Fix empty YAML mappings (`{}`) being silently dropped during parsing,
   which caused `EffectiveAll()` to miss leaf entities with empty configs
   ([#32](https://github.com/tarantool/go-config/issues/32)).
+* Preserve `isArray` flag when merging numeric children into the config tree,
+  so YAML sequences are correctly represented as arrays after inheritance
+  resolution
+  ([#34](https://github.com/tarantool/go-config/issues/34)).
 
 ## [v1.0.0] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ instance). It supports:
 ```go
 builder = builder.WithInheritance(
     config.Levels(config.Global, "groups", "replicasets", "instances"),
-    config.WithInheritMerge("roles", config.MergeAppend),
     config.WithInheritMerge("credentials", config.MergeDeep),
     config.WithNoInherit("leader"),
     config.WithDefaults(map[string]any{

--- a/inheritance.go
+++ b/inheritance.go
@@ -155,10 +155,10 @@ func WithNoInheritFrom(level string, keys ...string) InheritanceOption {
 //
 // Example:
 //
-//	WithInheritMerge("roles", config.MergeAppend)
+//	WithInheritMerge("roles", config.MergeReplace)
 //
 // means when group has roles=[storage] and instance has roles=[metrics],
-// the effective roles for that instance will be [storage, metrics].
+// the effective roles for that instance will be [metrics].
 func WithInheritMerge(key string, strategy InheritMergeStrategy) InheritanceOption {
 	return func(ic *inheritanceConfig) {
 		if ic.mergeStrategies == nil {

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -2,6 +2,8 @@ package config_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1319,4 +1321,50 @@ func TestConfig_Walk_ContextCancellation(t *testing.T) {
 		// Optional: check val.
 		_ = val
 	}
+}
+
+func TestWithInheritance_YamlArrayPreserved(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	yamlData := `groups:
+  storages:
+    roles:
+      - global-role
+    replicasets:
+      s-001:
+        instances:
+          s-001-a:
+            roles:
+              - instance-role
+`
+	err := os.WriteFile(cfgPath, []byte(yamlData), 0o600)
+	require.NoError(t, err)
+
+	collector, err := collectors.NewSource(
+		t.Context(), collectors.NewFile(cfgPath), collectors.NewYamlFormat())
+	require.NoError(t, err)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collector)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("roles", config.MergeAppend),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+	require.NotNil(t, cfg)
+
+	instanceCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var roles []string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("roles"), &roles)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"global-role", "instance-role"}, roles)
 }

--- a/integration/tarantool_integration_test.go
+++ b/integration/tarantool_integration_test.go
@@ -21,7 +21,7 @@ import (
 //   - two groups (routers, storages) with group-level overrides
 //   - multiple replicasets per group with replicaset-level overrides
 //   - multiple instances per replicaset with instance-level overrides
-//   - inheritance corner-cases: credentials (MergeDeep), roles (MergeAppend),
+//   - inheritance corner-cases: credentials (MergeDeep), roles (MergeReplace),
 //     leader (NoInherit), and scalar overrides (MergeReplace)
 const bigTarantoolConfig = `
 credentials:
@@ -301,13 +301,13 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	assert.Equal(t, "0.0.0.0:3311", rInstanceURI,
 		"instance iproto.listen should override group value")
 
-	// MergeAppend: group roles inherited.
+	// MergeReplace: group roles inherited.
 	var rRole0 string
 
 	_, err = routerCfg.Get(config.NewKeyPath("roles/0"), &rRole0)
 	require.NoError(t, err)
 	assert.Equal(t, "roles.metrics-export", rRole0,
-		"MergeAppend: group-level role should be present")
+		"group-level role should be present")
 
 	// 7b. Storage instance s-001-a.
 	s001aCfg, err := cfg.Effective(
@@ -356,13 +356,13 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "0.0.0.0:3321", sInstanceURI)
 
-	// MergeAppend: group roles.
+	// MergeReplace: group roles.
 	var sRole0 string
 
 	_, err = s001aCfg.Get(config.NewKeyPath("roles/0"), &sRole0)
 	require.NoError(t, err)
 	assert.Equal(t, "roles.crud-storage", sRole0,
-		"MergeAppend: group-level role should be present")
+		"group-level role should be present")
 
 	// 7c. Storage instance s-001-b — shares replicaset with s-001-a.
 	s001bCfg, err := cfg.Effective(
@@ -405,9 +405,7 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	assert.Equal(t, "global-admin-pw", s002aAdminPw,
 		"MergeDeep: global admin still present in s-002-a")
 
-	// roles: replicaset-level roles replace group-level roles because
-	// MergeAppend falls back to Replace when array nodes lose their
-	// isArray marking through the builder merge pipeline.
+	// roles: replicaset-level roles replace group-level roles.
 	var s002Role0 string
 
 	_, err = s002aCfg.Get(config.NewKeyPath("roles/0"), &s002Role0)
@@ -447,18 +445,12 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	}
 }
 
-// TestTarantool_Integration_WithRealSchema validates a config against the
-// embedded Tarantool schema bundle.
-//
-// Note: config uses only scalar and map fields (no YAML arrays) because
-// the builder merge pipeline currently does not preserve the isArray flag,
-// which causes array-typed fields to appear as maps to the JSON Schema
-// validator.
-func TestTarantool_Integration_WithRealSchema(t *testing.T) {
+func writeRealSchemaConfig(t *testing.T) string {
+	t.Helper()
+
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 
-	// Config using only scalar/map fields that pass the real schema.
 	writeTestFile(t, cfgPath, `
 log:
   level: info
@@ -470,26 +462,42 @@ replication:
 
 groups:
   storages:
+    roles:
+      - roles.crud-storage
     replicasets:
       s-001:
         instances:
           s-001-a: {}
+          s-001-b:
+            roles:
+              - roles.metrics-export
 `)
 
-	ctx := context.Background()
+	return cfgPath
+}
 
-	// Use an isolated env prefix to prevent ambient TT_* variables from
-	// entering the config and violating the real schema.
+func buildRealSchemaConfig(t *testing.T) config.Config {
+	t.Helper()
+
+	cfgPath := writeRealSchemaConfig(t)
+
 	cfg, err := tarantool.New().
 		WithConfigFile(cfgPath).
 		WithEnvPrefix("TT_TESTONLY_").
-		Build(ctx)
+		Build(context.Background())
 	require.NoError(t, err, "config should pass real Tarantool schema validation")
 
-	// Verify basic values.
+	return cfg
+}
+
+// TestTarantool_Integration_WithRealSchema_Build validates a config against
+// the embedded Tarantool schema bundle and reads top-level values.
+func TestTarantool_Integration_WithRealSchema_Build(t *testing.T) {
+	cfg := buildRealSchemaConfig(t)
+
 	var logLevel string
 
-	_, err = cfg.Get(config.NewKeyPath("log/level"), &logLevel)
+	_, err := cfg.Get(config.NewKeyPath("log/level"), &logLevel)
 	require.NoError(t, err)
 	assert.Equal(t, "info", logLevel)
 
@@ -498,25 +506,48 @@ groups:
 	_, err = cfg.Get(config.NewKeyPath("replication/failover"), &failover)
 	require.NoError(t, err)
 	assert.Equal(t, "election", failover)
+}
 
-	// Verify inheritance with real schema.
-	instanceCfg, err := cfg.Effective(
+// TestTarantool_Integration_WithRealSchema_Inheritance checks that
+// inheritance works correctly for instances with and without own roles.
+func TestTarantool_Integration_WithRealSchema_Inheritance(t *testing.T) {
+	cfg := buildRealSchemaConfig(t)
+
+	instanceACfg, err := cfg.Effective(
 		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
 	require.NoError(t, err)
 
 	var inheritedLevel string
 
-	_, err = instanceCfg.Get(config.NewKeyPath("log/level"), &inheritedLevel)
+	_, err = instanceACfg.Get(config.NewKeyPath("log/level"), &inheritedLevel)
 	require.NoError(t, err)
 	assert.Equal(t, "info", inheritedLevel,
 		"global log.level should be inherited")
 
 	var inheritedFailover string
 
-	_, err = instanceCfg.Get(config.NewKeyPath("replication/failover"), &inheritedFailover)
+	_, err = instanceACfg.Get(config.NewKeyPath("replication/failover"), &inheritedFailover)
 	require.NoError(t, err)
 	assert.Equal(t, "election", inheritedFailover,
 		"global replication.failover should be inherited")
+
+	var rolesA []string
+
+	_, err = instanceACfg.Get(config.NewKeyPath("roles"), &rolesA)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"roles.crud-storage"}, rolesA,
+		"instance without own roles should inherit group roles")
+
+	instanceBCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-b"))
+	require.NoError(t, err)
+
+	var rolesB []string
+
+	_, err = instanceBCfg.Get(config.NewKeyPath("roles"), &rolesB)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"roles.metrics-export"}, rolesB,
+		"instance-level roles should replace group-level roles")
 }
 
 // TestTarantool_Integration_BuildMutable_WithEtcd tests BuildMutable with

--- a/integration/tarantool_integration_test.go
+++ b/integration/tarantool_integration_test.go
@@ -22,7 +22,7 @@ import (
 //   - multiple replicasets per group with replicaset-level overrides
 //   - multiple instances per replicaset with instance-level overrides
 //   - inheritance corner-cases: credentials (MergeDeep), roles (MergeReplace),
-//     leader (NoInherit), and scalar overrides (MergeReplace)
+//     leader (inherited by default), and scalar overrides (MergeReplace)
 const bigTarantoolConfig = `
 credentials:
   users:
@@ -336,10 +336,13 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	assert.Equal(t, "op-pw-s001", sOpPw,
 		"MergeDeep: replicaset-level operator should be present")
 
-	// NoInherit: leader should NOT be in the instance config.
-	_, leaderFound := s001aCfg.Lookup(config.NewKeyPath("leader"))
-	assert.False(t, leaderFound,
-		"leader should not be inherited (NoInherit)")
+	// leader is inherited by default from replicaset level.
+	var leader string
+
+	_, err = s001aCfg.Get(config.NewKeyPath("leader"), &leader)
+	require.NoError(t, err)
+	assert.Equal(t, "s-001-a", leader,
+		"leader should be inherited from replicaset")
 
 	// Replicaset-level override: synchro_timeout = 10.
 	var synchroTimeout int64

--- a/merge.go
+++ b/merge.go
@@ -9,6 +9,21 @@ import (
 	"github.com/tarantool/go-config/tree"
 )
 
+// isNumericString reports whether str consists only of ASCII digits.
+func isNumericString(str string) bool {
+	if str == "" {
+		return false
+	}
+
+	for i := range len(str) {
+		if str[i] < '0' || str[i] > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
 // MergeCollector reads all values from a collector and merges them into the tree
 // using the default merging logic.
 // The collector's priority is determined by the caller (higher priority collectors
@@ -81,6 +96,10 @@ func mergeValue(root *tree.Node, keyPath keypath.KeyPath, value any, col Collect
 
 			child = tree.New()
 			node.SetChild(segment, child)
+		}
+
+		if !isLast && isNumericString(keyPath[i+1]) {
+			child.MarkArray()
 		}
 
 		if isLast {

--- a/merge_test.go
+++ b/merge_test.go
@@ -173,6 +173,57 @@ func TestMergeCollector_SliceReplacement(t *testing.T) {
 	assert.Equal(t, "third", itemsNode.Source)
 }
 
+func TestMergeValue_PreservesIsArrayForNumericKeys(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	col := collectors.NewMock().
+		WithEntry(config.NewKeyPath("roles/0"), "foo").
+		WithEntry(config.NewKeyPath("roles/1"), "bar").
+		WithName("test")
+
+	err := config.MergeCollector(t.Context(), root, col)
+	require.NoError(t, err)
+
+	rolesNode := root.Get(config.NewKeyPath("roles"))
+	require.NotNil(t, rolesNode)
+	assert.True(t, rolesNode.IsArray(),
+		"parent of numeric children should be marked as array")
+
+	raw := tree.ToAny(rolesNode)
+	assert.Equal(t, []any{"foo", "bar"}, raw)
+}
+
+func TestMergeValue_PreservesIsArrayForNestedNumericKeys(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	col := collectors.NewMock().
+		WithEntry(config.NewKeyPath("outer/0/inner/0"), "a").
+		WithEntry(config.NewKeyPath("outer/0/inner/1"), "b").
+		WithEntry(config.NewKeyPath("outer/1/value"), "c").
+		WithName("test")
+
+	err := config.MergeCollector(t.Context(), root, col)
+	require.NoError(t, err)
+
+	outerNode := root.Get(config.NewKeyPath("outer"))
+	require.NotNil(t, outerNode)
+	assert.True(t, outerNode.IsArray(),
+		"outer should be marked as array")
+
+	innerNode := root.Get(config.NewKeyPath("outer/0/inner"))
+	require.NotNil(t, innerNode)
+	assert.True(t, innerNode.IsArray(),
+		"inner should be marked as array")
+
+	raw := tree.ToAny(outerNode)
+	assert.Equal(t, []any{
+		map[string]any{"inner": []any{"a", "b"}},
+		map[string]any{"value": "c"},
+	}, raw)
+}
+
 func TestMergeCollectorWithMerger_ErrorInMergeValue(t *testing.T) {
 	t.Parallel()
 

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -54,7 +54,7 @@ type Builder struct {
 // New creates a Builder with Tarantool defaults:
 //   - env prefix: "TT_"
 //   - inheritance: Global → groups → replicasets → instances
-//   - default inheritance options: credentials(MergeDeep), roles(MergeAppend), leader(NoInherit)
+//   - default inheritance options: credentials(MergeDeep), leader(NoInherit)
 //   - schema: the newest embedded Tarantool version is used offline by default
 func New() *Builder {
 	return &Builder{ //nolint:exhaustruct
@@ -192,8 +192,7 @@ func (b *Builder) WithoutSchema() *Builder {
 }
 
 // WithInheritanceOption adds extra inheritance options on top of the
-// Tarantool defaults (credentials=MergeDeep, roles=MergeAppend,
-// leader=NoInherit).
+// Tarantool defaults (credentials=MergeDeep, leader=NoInherit).
 func (b *Builder) WithInheritanceOption(opts ...config.InheritanceOption) *Builder {
 	b.inheritanceOpts = append(b.inheritanceOpts, opts...)
 	return b
@@ -289,7 +288,6 @@ func ConfigPrefix(base string) string {
 func tarantoolInheritanceOpts() []config.InheritanceOption {
 	return []config.InheritanceOption{
 		config.WithInheritMerge("credentials", config.MergeDeep),
-		config.WithInheritMerge("roles", config.MergeAppend),
 		config.WithNoInherit("leader"),
 	}
 }

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -54,7 +54,7 @@ type Builder struct {
 // New creates a Builder with Tarantool defaults:
 //   - env prefix: "TT_"
 //   - inheritance: Global → groups → replicasets → instances
-//   - default inheritance options: credentials(MergeDeep), leader(NoInherit)
+//   - default inheritance options: credentials(MergeDeep)
 //   - schema: the newest embedded Tarantool version is used offline by default
 func New() *Builder {
 	return &Builder{ //nolint:exhaustruct
@@ -192,7 +192,7 @@ func (b *Builder) WithoutSchema() *Builder {
 }
 
 // WithInheritanceOption adds extra inheritance options on top of the
-// Tarantool defaults (credentials=MergeDeep, leader=NoInherit).
+// Tarantool defaults (credentials=MergeDeep).
 func (b *Builder) WithInheritanceOption(opts ...config.InheritanceOption) *Builder {
 	b.inheritanceOpts = append(b.inheritanceOpts, opts...)
 	return b
@@ -288,7 +288,6 @@ func ConfigPrefix(base string) string {
 func tarantoolInheritanceOpts() []config.InheritanceOption {
 	return []config.InheritanceOption{
 		config.WithInheritMerge("credentials", config.MergeDeep),
-		config.WithNoInherit("leader"),
 	}
 }
 

--- a/tarantool/builder_test.go
+++ b/tarantool/builder_test.go
@@ -298,9 +298,49 @@ groups:
 	require.NoError(t, err)
 	assert.Equal(t, "manual", failover)
 
-	// leader should NOT be inherited (NoInherit).
+	// leader should be inherited from replicaset level by default.
+	var leader string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("leader"), &leader)
+	require.NoError(t, err)
+	assert.Equal(t, "s-001-a", leader)
+}
+
+func TestBuild_Inheritance_LeaderCanBeExcluded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, cfgPath, `
+replication:
+  failover: manual
+groups:
+  storages:
+    replicasets:
+      s-001:
+        leader: s-001-a
+        instances:
+          s-001-a:
+            iproto:
+              listen: 3301
+`)
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithoutSchema().
+		WithInheritanceOption(config.WithNoInherit("leader")).
+		Build(ctx)
+	require.NoError(t, err)
+
+	instanceCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// leader should NOT be inherited when explicitly excluded.
 	_, ok := instanceCfg.Lookup(config.NewKeyPath("leader"))
-	assert.False(t, ok, "leader should not be inherited")
+	assert.False(t, ok, "leader should not be inherited when excluded")
 }
 
 func TestBuild_InheritanceMergeDeep(t *testing.T) {

--- a/tarantool/doc.go
+++ b/tarantool/doc.go
@@ -28,7 +28,6 @@
 // The builder registers the Tarantool hierarchy
 // (Global → groups → replicasets → instances) with default merge strategies:
 //   - credentials — MergeDeep
-//   - roles       — MergeAppend
 //   - leader      — NoInherit
 //
 // # Schema Validation

--- a/tarantool/doc.go
+++ b/tarantool/doc.go
@@ -28,7 +28,6 @@
 // The builder registers the Tarantool hierarchy
 // (Global → groups → replicasets → instances) with default merge strategies:
 //   - credentials — MergeDeep
-//   - leader      — NoInherit
 //
 // # Schema Validation
 //


### PR DESCRIPTION
Before this change, YAML sequences were parsed with isArray=true, but the flag was lost during Build() because mergeValue() created intermediate nodes without marking the parent as an array. After inheritance resolution, array fields appeared as map[string]any with numeric string keys instead of []any.

This caused downstream code expecting slices (e.g. roles, listen) to receive maps and silently fail or drop data.

Remove the redundant explicit MergeReplace strategy for roles from tarantool.Builder defaults, since MergeReplace is already the default inheritance behavior and does not need to be specified.

Closes #34