### PR TITLE
tarantool: remove hardcoded leader NoInherit exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Remove redundant `roles` merge strategy from `tarantool.Builder` defaults
   since `MergeReplace` is already the default inheritance behavior
   ([#34](https://github.com/tarantool/go-config/issues/34)).
+* Remove hardcoded `leader` exclusion from `tarantool.Builder` default
+  inheritance options so `leader` is now inherited down the hierarchy
+  like other keys. Users who need the old behavior can opt out via
+  `WithInheritanceOption(config.WithNoInherit("leader"))`
+  ([#36](https://github.com/tarantool/go-config/issues/36)).
 
 ### Fixed
 

--- a/integration/tarantool_integration_test.go
+++ b/integration/tarantool_integration_test.go
@@ -22,7 +22,7 @@ import (
 //   - multiple replicasets per group with replicaset-level overrides
 //   - multiple instances per replicaset with instance-level overrides
 //   - inheritance corner-cases: credentials (MergeDeep), roles (MergeReplace),
-//     leader (NoInherit), and scalar overrides (MergeReplace)
+//     leader (inherited by default), and scalar overrides (MergeReplace)
 const bigTarantoolConfig = `
 credentials:
   users:
@@ -336,10 +336,13 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	assert.Equal(t, "op-pw-s001", sOpPw,
 		"MergeDeep: replicaset-level operator should be present")
 
-	// NoInherit: leader should NOT be in the instance config.
-	_, leaderFound := s001aCfg.Lookup(config.NewKeyPath("leader"))
-	assert.False(t, leaderFound,
-		"leader should not be inherited (NoInherit)")
+	// leader is inherited by default from replicaset level.
+	var leader string
+
+	_, err = s001aCfg.Get(config.NewKeyPath("leader"), &leader)
+	require.NoError(t, err)
+	assert.Equal(t, "s-001-a", leader,
+		"leader should be inherited from replicaset")
 
 	// Replicaset-level override: synchro_timeout = 10.
 	var synchroTimeout int64

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -50,7 +50,7 @@ type Builder struct {
 // New creates a Builder with Tarantool defaults:
 //   - env prefix: "TT_"
 //   - inheritance: Global → groups → replicasets → instances
-//   - default inheritance options: credentials(MergeDeep), leader(NoInherit)
+//   - default inheritance options: credentials(MergeDeep)
 //   - schema: the newest embedded Tarantool version is used offline by default
 func New() *Builder {
 	return &Builder{ //nolint:exhaustruct
@@ -176,7 +176,7 @@ func (b *Builder) WithoutSchema() *Builder {
 }
 
 // WithInheritanceOption adds extra inheritance options on top of the
-// Tarantool defaults (credentials=MergeDeep, leader=NoInherit).
+// Tarantool defaults (credentials=MergeDeep).
 func (b *Builder) WithInheritanceOption(opts ...config.InheritanceOption) *Builder {
 	b.inheritanceOpts = append(b.inheritanceOpts, opts...)
 	return b
@@ -272,7 +272,6 @@ func ConfigPrefix(base string) string {
 func tarantoolInheritanceOpts() []config.InheritanceOption {
 	return []config.InheritanceOption{
 		config.WithInheritMerge("credentials", config.MergeDeep),
-		config.WithNoInherit("leader"),
 	}
 }
 

--- a/tarantool/builder_test.go
+++ b/tarantool/builder_test.go
@@ -298,9 +298,49 @@ groups:
 	require.NoError(t, err)
 	assert.Equal(t, "manual", failover)
 
-	// leader should NOT be inherited (NoInherit).
+	// leader should be inherited from replicaset level by default.
+	var leader string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("leader"), &leader)
+	require.NoError(t, err)
+	assert.Equal(t, "s-001-a", leader)
+}
+
+func TestBuild_Inheritance_LeaderCanBeExcluded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, cfgPath, `
+replication:
+  failover: manual
+groups:
+  storages:
+    replicasets:
+      s-001:
+        leader: s-001-a
+        instances:
+          s-001-a:
+            iproto:
+              listen: 3301
+`)
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithoutSchema().
+		WithInheritanceOption(config.WithNoInherit("leader")).
+		Build(ctx)
+	require.NoError(t, err)
+
+	instanceCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// leader should NOT be inherited when explicitly excluded.
 	_, ok := instanceCfg.Lookup(config.NewKeyPath("leader"))
-	assert.False(t, ok, "leader should not be inherited")
+	assert.False(t, ok, "leader should not be inherited when excluded")
 }
 
 func TestBuild_InheritanceMergeDeep(t *testing.T) {

--- a/tarantool/doc.go
+++ b/tarantool/doc.go
@@ -18,7 +18,6 @@
 // The builder registers the Tarantool hierarchy
 // (Global → groups → replicasets → instances) with default merge strategies:
 //   - credentials — MergeDeep
-//   - leader      — NoInherit
 //
 // # Schema Validation
 //


### PR DESCRIPTION
Remove the hardcoded `WithNoInherit("leader")` default from `tarantool.Builder`.

In Tarantool 3.x cluster configurations, `leader` is typically defined at the replicaset level and individual instances inherit it to determine the RW leader in `replication.failover: manual` mode. Because the exclusion was hardcoded with no way to override it, instances always saw an empty `leader` value, breaking downstream consumers like `go-discovery`.

Users who still need the old behavior can opt out via:
```go
WithInheritanceOption(config.WithNoInherit("leader"))
```

Closes #36