### PR TITLE
tarantool: automate JSON Schema sync from upstream

### DIFF
--- a/.github/workflows/sync-tarantool-schemas.yaml
+++ b/.github/workflows/sync-tarantool-schemas.yaml
@@ -1,0 +1,83 @@
+name: Sync Tarantool schemas
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Fetch and validate only — do not commit, push, or open a PR."
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-tarantool-schemas
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: 1.25
+  BOT_NAME: "github-actions[bot]"
+  BOT_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+  PR_BRANCH: automation/sync-tarantool-schemas
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: run schemasync
+        id: schemasync
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            args+=("--dry-run")
+            echo "::notice::dry-run enabled; no PR will be opened"
+          fi
+          go run ./internal/tools/schemasync "${args[@]}" | tee schemasync.out
+          added=$(grep '^added=' schemasync.out | cut -d= -f2-)
+          echo "added=${added}" >> "$GITHUB_OUTPUT"
+
+      - name: check for changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain tarantool/schemas/)" ]; then
+            echo "no new schemas"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: validate embedded schemas
+        if: steps.changes.outputs.changed == 'true'
+        run: go test ./tarantool/... -count=1
+
+      - name: create pull request
+        if: steps.changes.outputs.changed == 'true' && inputs.dry_run != true
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ github.token }}
+          branch: ${{ env.PR_BRANCH }}
+          base: master
+          add-paths: tarantool/schemas
+          commit-message: "tarantool: embed JSON Schemas for ${{ steps.schemasync.outputs.added }}"
+          committer: "${{ env.BOT_NAME }} <${{ env.BOT_EMAIL }}>"
+          author: "${{ env.BOT_NAME }} <${{ env.BOT_EMAIL }}>"
+          title: "tarantool: embed JSON Schemas for ${{ steps.schemasync.outputs.added }}"
+          body: "Automated sync of Tarantool JSON Schemas. Added versions: ${{ steps.schemasync.outputs.added }}."
+          delete-branch: true

--- a/internal/tools/schemasync/main.go
+++ b/internal/tools/schemasync/main.go
@@ -1,0 +1,55 @@
+// Package main is the schemasync CLI entry point.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Config format is only stable starting with Tarantool 3.
+const defaultMinMajor = 3
+
+const defaultHTTPTimeout = 30 * time.Second
+
+const schemaURLDefault = "https://download.tarantool.org/tarantool/schema/config.schema.%s.json"
+
+func main() {
+	var (
+		repo        = flag.String("repo", "tarantool/tarantool", "GitHub repository in owner/name form.")
+		schemasDir  = flag.String("schemas-dir", "tarantool/schemas", "Versioned-schema directory root.")
+		schemaURL   = flag.String("schema-url", schemaURLDefault, "Schema URL template (%s = version).")
+		minMajor    = flag.Int("min-major", defaultMinMajor, "Minimum major version to consider.")
+		dryRun      = flag.Bool("dry-run", false, "Discover and validate without writing.")
+		githubToken = flag.String("github-token", "", "GitHub API token; falls back to $GITHUB_TOKEN.")
+	)
+
+	flag.Parse()
+
+	token := *githubToken
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	cfg := Config{
+		Repo:        *repo,
+		SchemasDir:  *schemasDir,
+		SchemaURL:   *schemaURL,
+		GitHubToken: token,
+		MinMajor:    *minMajor,
+		DryRun:      *dryRun,
+		HTTPClient:  &http.Client{Timeout: defaultHTTPTimeout}, //nolint:exhaustruct
+		Logger:      logger,
+	}
+
+	err := Run(context.Background(), cfg)
+	if err != nil {
+		logger.Error("schemasync failed", "err", err)
+		os.Exit(1)
+	}
+}

--- a/internal/tools/schemasync/sync.go
+++ b/internal/tools/schemasync/sync.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kaptinlin/jsonschema"
+)
+
+// Presence of this file — not the directory — defines whether a version is
+// considered present on disk.
+const schemaFileName = "config.schema.json.gz"
+
+const maxSchemaBodyBytes = 32 << 20
+
+const dirPerm os.FileMode = 0o750
+
+var (
+	errNilHTTPClient = errors.New("schemasync: Config.HTTPClient is nil")
+	errNilLogger     = errors.New("schemasync: Config.Logger is nil")
+)
+
+var errUnexpectedStatus = errors.New("unexpected http status")
+
+type Config struct {
+	Repo        string
+	SchemasDir  string
+	SchemaURL   string
+	GitHubToken string
+	MinMajor    int
+	DryRun      bool
+	HTTPClient  *http.Client
+	Logger      *slog.Logger
+}
+
+// Run prints exactly one stdout line of the form "added=<csv>" as the
+// machine-readable handoff to the workflow step that opens the PR.
+func Run(ctx context.Context, cfg Config) error {
+	if cfg.HTTPClient == nil {
+		return errNilHTTPClient
+	}
+
+	if cfg.Logger == nil {
+		return errNilLogger
+	}
+
+	tags, err := fetchTags(ctx, cfg.HTTPClient, cfg.Repo, cfg.GitHubToken)
+	if err != nil {
+		return fmt.Errorf("fetch tags: %w", err)
+	}
+
+	stable := filterStableTags(tags, cfg.MinMajor)
+
+	missing, err := missingVersions(cfg.SchemasDir, stable)
+	if err != nil {
+		return fmt.Errorf("diff missing versions: %w", err)
+	}
+
+	added := make([]string, 0, len(missing))
+
+	for _, version := range missing {
+		url := fmt.Sprintf(cfg.SchemaURL, version)
+
+		data, ok, fetchErr := fetchSchema(ctx, cfg.HTTPClient, url)
+		if fetchErr != nil {
+			return fmt.Errorf("fetch schema %s: %w", version, fetchErr)
+		}
+
+		if !ok {
+			cfg.Logger.Info("skip", "version", version, "reason", "upstream 404", "url", url)
+
+			continue
+		}
+
+		validateErr := validateSchema(data)
+		if validateErr != nil {
+			return fmt.Errorf("validate schema %s: %w", version, validateErr)
+		}
+
+		if cfg.DryRun {
+			cfg.Logger.Info("add", "version", version, "dry_run", true, "bytes", len(data))
+
+			added = append(added, version)
+
+			continue
+		}
+
+		writeErr := writeSchemaGz(cfg.SchemasDir, version, data)
+		if writeErr != nil {
+			return fmt.Errorf("write schema %s: %w", version, writeErr)
+		}
+
+		cfg.Logger.Info("add", "version", version, "bytes", len(data))
+
+		added = append(added, version)
+	}
+
+	_, err = fmt.Fprintf(os.Stdout, "added=%s\n", strings.Join(added, ","))
+	if err != nil {
+		return fmt.Errorf("write stdout: %w", err)
+	}
+
+	return nil
+}
+
+// fetchSchema soft-skips 404 because upstream publishes schemas asynchronously
+// relative to tags.
+func fetchSchema(ctx context.Context, client *http.Client, url string) ([]byte, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("http do: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxSchemaBodyBytes))
+		if readErr != nil {
+			return nil, false, fmt.Errorf("read body: %w", readErr)
+		}
+
+		return data, true, nil
+	case http.StatusNotFound:
+		return nil, false, nil
+	default:
+		return nil, false, fmt.Errorf("%w: %d for %s", errUnexpectedStatus, resp.StatusCode, url)
+	}
+}
+
+// validateSchema must succeed before writing — a schema that doesn't compile
+// would poison the embedded registry at package init time.
+func validateSchema(data []byte) error {
+	_, err := jsonschema.NewCompiler().Compile(data)
+	if err != nil {
+		return fmt.Errorf("schema failed to compile: %w", err)
+	}
+
+	return nil
+}
+
+// writeSchemaGz writes atomically (temp + rename) and deterministically so
+// reruns on the same inputs produce byte-identical output.
+func writeSchemaGz(schemasDir, version string, data []byte) error {
+	versionDir := filepath.Join(schemasDir, version)
+
+	mkdirErr := os.MkdirAll(versionDir, dirPerm)
+	if mkdirErr != nil {
+		return fmt.Errorf("mkdir %q: %w", versionDir, mkdirErr)
+	}
+
+	finalPath := filepath.Join(versionDir, schemaFileName)
+
+	tmp, err := os.CreateTemp(versionDir, schemaFileName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+
+	tmpPath := tmp.Name()
+
+	writeErr := writeGzipBody(tmp, data)
+	if writeErr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+
+		return fmt.Errorf("write gzip body: %w", writeErr)
+	}
+
+	err = tmp.Close()
+	if err != nil {
+		_ = os.Remove(tmpPath)
+
+		return fmt.Errorf("tmp close: %w", err)
+	}
+
+	err = os.Rename(tmpPath, finalPath)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+
+		return fmt.Errorf("rename %q -> %q: %w", tmpPath, finalPath, err)
+	}
+
+	return nil
+}
+
+// writeGzipBody does NOT close w; the caller owns the underlying file.
+func writeGzipBody(w io.Writer, data []byte) error {
+	writer, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("gzip writer: %w", err)
+	}
+
+	// Zero non-deterministic fields so reruns produce byte-identical output.
+	const gzipOSUnknown byte = 255 // RFC 1952 "unknown".
+
+	writer.ModTime = time.Time{}
+	writer.Name = ""
+	writer.Comment = ""
+	writer.Extra = nil
+	writer.OS = gzipOSUnknown
+
+	_, err = writer.Write(data)
+	if err != nil {
+		_ = writer.Close()
+
+		return fmt.Errorf("gzip write: %w", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return fmt.Errorf("gzip close: %w", err)
+	}
+
+	return nil
+}
+
+// missingVersions preserves the input order of upstream.
+func missingVersions(schemasDir string, upstream []string) ([]string, error) {
+	present, err := presentVersions(schemasDir)
+	if err != nil {
+		return nil, err
+	}
+
+	missing := make([]string, 0, len(upstream))
+
+	for _, v := range upstream {
+		_, ok := present[v]
+		if !ok {
+			missing = append(missing, v)
+		}
+	}
+
+	return missing, nil
+}
+
+func presentVersions(schemasDir string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(schemasDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]struct{}{}, nil
+		}
+
+		return nil, fmt.Errorf("read schemas dir %q: %w", schemasDir, err)
+	}
+
+	present := make(map[string]struct{}, len(entries))
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		gzPath := filepath.Join(schemasDir, entry.Name(), schemaFileName)
+
+		info, err := os.Stat(gzPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
+			return nil, fmt.Errorf("stat %q: %w", gzPath, err)
+		}
+
+		if info.Mode().IsRegular() {
+			present[entry.Name()] = struct{}{}
+		}
+	}
+
+	return present, nil
+}

--- a/internal/tools/schemasync/sync_test.go
+++ b/internal/tools/schemasync/sync_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDirPerm  os.FileMode = 0o750
+	testFilePerm os.FileMode = 0o600
+)
+
+func TestMissingVersions(t *testing.T) {
+	t.Parallel()
+
+	type fsEntry struct {
+		version   string
+		hasGzFile bool
+	}
+
+	tests := []struct {
+		name     string
+		fs       []fsEntry
+		upstream []string
+		want     []string
+	}{
+		{
+			name: "disjoint sets — all upstream missing",
+			fs: []fsEntry{
+				{version: "3.0.0", hasGzFile: true},
+			},
+			upstream: []string{"3.7.1", "4.0.0"},
+			want:     []string{"3.7.1", "4.0.0"},
+		},
+		{
+			name: "full overlap — nothing missing",
+			fs: []fsEntry{
+				{version: "3.0.0", hasGzFile: true},
+				{version: "3.7.1", hasGzFile: true},
+			},
+			upstream: []string{"3.0.0", "3.7.1"},
+			want:     []string{},
+		},
+		{
+			name:     "empty upstream — nothing missing",
+			fs:       []fsEntry{{version: "3.0.0", hasGzFile: true}},
+			upstream: []string{},
+			want:     []string{},
+		},
+		{
+			name:     "empty filesystem — everything missing",
+			fs:       nil,
+			upstream: []string{"3.0.0", "3.7.1"},
+			want:     []string{"3.0.0", "3.7.1"},
+		},
+		{
+			name: "version directory without gz is counted as missing",
+			fs: []fsEntry{
+				{version: "3.0.0", hasGzFile: false},
+			},
+			upstream: []string{"3.0.0"},
+			want:     []string{"3.0.0"},
+		},
+		{
+			name: "preserves upstream input order, not alphabetical",
+			fs: []fsEntry{
+				{version: "3.7.1", hasGzFile: true},
+			},
+			upstream: []string{"4.0.0", "3.0.0", "3.7.1"},
+			want:     []string{"4.0.0", "3.0.0"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			for _, e := range testCase.fs {
+				verDir := filepath.Join(dir, e.version)
+				require.NoError(t, os.MkdirAll(verDir, testDirPerm))
+
+				if e.hasGzFile {
+					gzPath := filepath.Join(verDir, "config.schema.json.gz")
+					require.NoError(t, os.WriteFile(gzPath, []byte("placeholder"), testFilePerm))
+				}
+			}
+
+			got, err := missingVersions(dir, testCase.upstream)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// repoRootRelativeSchema uses runtime.Caller because it is stable across
+// `go test` invocations from different cwd, while a relative filepath is not.
+func repoRootRelativeSchema(t *testing.T, version string) string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller failed")
+	// schemasync -> tools -> internal -> <repo>.
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+
+	return filepath.Join(repoRoot, "tarantool", "schemas", version, "config.schema.json.gz")
+}
+
+func TestValidateSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("real embedded schema compiles", func(t *testing.T) {
+		t.Parallel()
+
+		gzPath := repoRootRelativeSchema(t, "3.3.0")
+
+		gzBytes, err := os.ReadFile(gzPath) //nolint:gosec
+		require.NoError(t, err)
+
+		reader, err := gzip.NewReader(bytes.NewReader(gzBytes))
+		require.NoError(t, err)
+
+		plain, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+
+		require.NoError(t, validateSchema(plain))
+	})
+
+	t.Run("garbage bytes fail with wrapped error", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateSchema([]byte("not json"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "schema failed to compile")
+	})
+}
+
+func TestWriteSchemaGz_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object"}`)
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	require.NoError(t, writeSchemaGz(dirA, "3.9.9", payload))
+	require.NoError(t, writeSchemaGz(dirB, "3.9.9", payload))
+
+	gzA, err := os.ReadFile(filepath.Join(dirA, "3.9.9", schemaFileName)) //nolint:gosec
+	require.NoError(t, err)
+
+	gzB, err := os.ReadFile(filepath.Join(dirB, "3.9.9", schemaFileName)) //nolint:gosec
+	require.NoError(t, err)
+
+	assert.Equal(t, gzA, gzB, "same inputs must produce byte-identical gzip output")
+
+	reader, err := gzip.NewReader(bytes.NewReader(gzA))
+	require.NoError(t, err)
+
+	round, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	assert.Equal(t, payload, round)
+}
+
+func TestFetchSchema_SoftSkip404(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	data, ok, err := fetchSchema(context.Background(), srv.Client(), srv.URL+"/missing.json")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, data)
+}
+
+func TestFetchSchema_Hard500(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	data, ok, err := fetchSchema(context.Background(), srv.Client(), srv.URL+"/boom.json")
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, data)
+}

--- a/internal/tools/schemasync/tags.go
+++ b/internal/tools/schemasync/tags.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var stableTagRE = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)$`)
+
+var linkNextRE = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
+
+var errTagsStatus = errors.New("github tags: unexpected http status")
+
+// filterStableTags strips a leading "v" from output (e.g. "v3.7.1" → "3.7.1")
+// and preserves input order.
+func filterStableTags(names []string, minMajor int) []string {
+	out := make([]string, 0, len(names))
+
+	for _, name := range names {
+		match := stableTagRE.FindStringSubmatch(name)
+		if match == nil {
+			continue
+		}
+
+		major, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+
+		if major < minMajor {
+			continue
+		}
+
+		out = append(out, strings.TrimPrefix(name, "v"))
+	}
+
+	return out
+}
+
+// fetchTags returns names in API order (newest first). Empty token works for
+// public repos but hits a tighter rate limit.
+func fetchTags(ctx context.Context, client *http.Client, repo, token string) ([]string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/tags?per_page=100", repo)
+
+	var names []string
+
+	for url != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+
+		req.Header.Set("Accept", "application/vnd.github+json")
+
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("http do %s: %w", url, err)
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+
+		if readErr != nil {
+			return nil, fmt.Errorf("read body %s: %w", url, readErr)
+		}
+
+		if closeErr != nil {
+			return nil, fmt.Errorf("close body %s: %w", url, closeErr)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("%w: %d for %s: %s", errTagsStatus, resp.StatusCode, url, truncate(body))
+		}
+
+		var page []struct {
+			Name string `json:"name"`
+		}
+
+		err = json.Unmarshal(body, &page)
+		if err != nil {
+			return nil, fmt.Errorf("decode tags %s: %w", url, err)
+		}
+
+		for _, entry := range page {
+			names = append(names, entry.Name)
+		}
+
+		url = nextLink(resp.Header.Get("Link"))
+	}
+
+	return names, nil
+}
+
+func nextLink(header string) string {
+	if header == "" {
+		return ""
+	}
+
+	match := linkNextRE.FindStringSubmatch(header)
+	if match == nil {
+		return ""
+	}
+
+	return match[1]
+}
+
+func truncate(body []byte) string {
+	const maxLen = 256
+
+	if len(body) <= maxLen {
+		return string(body)
+	}
+
+	return string(body[:maxLen]) + "..."
+}

--- a/internal/tools/schemasync/tags_test.go
+++ b/internal/tools/schemasync/tags_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterStableTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []string
+		minMajor int
+		want     []string
+	}{
+		{
+			name:     "v-prefixed stable tag is kept and stripped",
+			input:    []string{"v3.0.0"},
+			minMajor: 3,
+			want:     []string{"3.0.0"},
+		},
+		{
+			name:     "plain semver without v prefix is kept as-is",
+			input:    []string{"3.7.1"},
+			minMajor: 3,
+			want:     []string{"3.7.1"},
+		},
+		{
+			name:     "pre-release suffix rc1 is dropped",
+			input:    []string{"v3.0.0-rc1"},
+			minMajor: 3,
+			want:     []string{},
+		},
+		{
+			name:     "entrypoint suffix is dropped",
+			input:    []string{"v3.0.0-entrypoint"},
+			minMajor: 3,
+			want:     []string{},
+		},
+		{
+			name:     "major below minMajor is dropped",
+			input:    []string{"v2.11.4"},
+			minMajor: 3,
+			want:     []string{},
+		},
+		{
+			name:     "major above minMajor is kept",
+			input:    []string{"v4.0.0"},
+			minMajor: 3,
+			want:     []string{"4.0.0"},
+		},
+		{
+			name:     "non-semver tag is dropped",
+			input:    []string{"release-3.0"},
+			minMajor: 3,
+			want:     []string{},
+		},
+		{
+			name:     "empty string is dropped",
+			input:    []string{""},
+			minMajor: 3,
+			want:     []string{},
+		},
+		{
+			name:     "mixed input preserves input order",
+			input:    []string{"v3.0.0", "v2.11.4", "3.7.1", "v3.0.0-rc1", "v4.0.0", "release-3.0", ""},
+			minMajor: 3,
+			want:     []string{"3.0.0", "3.7.1", "4.0.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterStableTags(tc.input, tc.minMajor)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Add internal/tools/schemasync CLI and a daily GitHub Actions workflow that fetches new Tarantool JSON Schemas, validates them, and opens a PR. Schemas land in tarantool/schemas/ without manual fetch/gzip/commit.

Closes #28