### PR TITLE
config: implement mutable configuration methods with rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+* Thread-safe mutable configuration API on `MutableConfig`: `Set`, `Merge`,
+  `Update`, `Delete` validate the resulting tree and roll back to the previous
+  state on failure, and read methods (`Get`, `Lookup`, `Stat`, `Walk`, `Slice`,
+  `Effective`, `EffectiveAll`) take a read lock. Modified keys get a bumped
+  revision and `"modified"` source.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ merging and resolves effective configuration for any entity in the hierarchy.
 - Multiple Sources: load configuration from maps, files, directories,
   environment variables, or centralized key-value storages (etcd, TCS)
 - Order Preservation: maintain insertion order of keys when needed
+- Mutable Configuration: thread-safe runtime modifications with
+  validation
 - Reactive Watch: monitor storage changes via the Watcher interface
 - Custom Mergers: full control over how collector values are merged into
   the configuration tree
@@ -198,22 +200,27 @@ Collectors are pluggable data sources. Each implements the `Collector` interface
 and streams configuration values via a channel.
 
 #### Map Collector
+
 Reads configuration from an in-memory `map[string]any`. Useful for defaults
 and tests.
 
 #### File / Source Collector
+
 Reads configuration from a single file (e.g., YAML) using the `DataSource` and
 `Format` interfaces.
 
 #### Directory Collector
+
 Reads all matching files from a directory (e.g., `*.yaml`). Each file is merged
 independently as a sub-collector. Supports recursive scanning.
 
 #### Env Collector
+
 Reads configuration from environment variables with a configurable prefix and
 key transformation.
 
 #### Storage Collector
+
 Reads multiple configuration documents from a centralized key-value storage
 (etcd, TCS) under a common prefix with integrity verification via
 [go-storage](https://github.com/tarantool/go-storage).
@@ -254,6 +261,24 @@ builder, err := builder.WithJSONSchema(schemaReader)
 builder = builder.WithValidator(myValidator)
 ```
 
+### Mutable Configuration
+
+`BuildMutable()` returns a `MutableConfig` that allows thread-safe runtime
+modifications:
+
+```go
+cfg, errs := builder.BuildMutable()
+
+// Set a single value.
+err := cfg.Set(config.NewKeyPath("server/port"), 9090)
+
+// Merge another config.
+err = cfg.Merge(&otherConfig)
+
+// Update only existing keys.
+err = cfg.Update(&patchConfig)
+```
+
 ### Examples
 
 Runnable examples are available in the root package as `Example_*` test
@@ -267,6 +292,8 @@ functions. Run them all with `go test -v -run Example ./...`.
 | `Example_walkConfig` | Iterating leaf values with `Walk`, depth control, and sub-paths |
 | `Example_sliceConfig` | Extracting a sub-configuration with `Slice` |
 | `Example_effectiveAll` | Resolving all leaf entities at once with `EffectiveAll` |
+| `Example_mutableConfig` | Runtime modifications via `BuildMutable`, `Set`, `Merge`, `Update` |
+
 #### Collectors — [`example_collectors_test.go`](example_collectors_test.go)
 
 | Example | Description |

--- a/builder.go
+++ b/builder.go
@@ -200,7 +200,6 @@ func (b *Builder) Build(ctx context.Context) (Config, []error) {
 
 // BuildMutable starts the configuration assembly process but returns
 // a mutable MutableConfig object that allows changes after creation.
-// Note: this method is not implemented yet and is under active development.
 func (b *Builder) BuildMutable(ctx context.Context) (MutableConfig, []error) {
 	cfg, errs := b.Build(ctx)
 	if len(errs) > 0 {

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/tarantool/go-config/keypath"
@@ -382,70 +383,164 @@ type MutableConfig struct {
 	validator validator.Validator
 }
 
+// nextRevision increments a revision string. Non-numeric or empty revisions start from "1".
+func nextRevision(cur string) string {
+	n, err := strconv.ParseUint(cur, 10, 64)
+	if err != nil {
+		n = 0
+	}
+
+	return strconv.FormatUint(n+1, 10)
+}
+
+// markModified updates a node's Source and Revision to reflect a runtime modification.
+func markModified(node *tree.Node) {
+	if node == nil {
+		return
+	}
+
+	node.Source = "modified"
+	node.Revision = nextRevision(node.Revision)
+}
+
+// Get retrieves a value at the specified path with read-lock protection.
+func (mc *MutableConfig) Get(path KeyPath, dest any) (MetaInfo, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.Get(path, dest)
+}
+
+// Lookup searches for a value by key with read-lock protection.
+func (mc *MutableConfig) Lookup(path KeyPath) (Value, bool) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.Lookup(path)
+}
+
+// Stat returns metadata for a key with read-lock protection.
+func (mc *MutableConfig) Stat(path KeyPath) (MetaInfo, bool) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.Stat(path)
+}
+
+// Walk returns a channel of all key-value pairs with read-lock protection.
+// The tree is cloned under the lock so the channel can be consumed safely after unlock.
+func (mc *MutableConfig) Walk(ctx context.Context, path KeyPath, depth int) (<-chan Value, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	snap := newConfig(cloneNode(mc.root), mc.inheritances)
+
+	return snap.Walk(ctx, path, depth)
+}
+
+// Slice returns a sub-configuration at the given path with read-lock protection.
+func (mc *MutableConfig) Slice(path KeyPath) (Config, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.Slice(path)
+}
+
+// Effective returns the resolved config for a specific leaf entity with read-lock protection.
+func (mc *MutableConfig) Effective(path KeyPath) (Config, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.Effective(path)
+}
+
+// EffectiveAll returns resolved configs for all leaf entities with read-lock protection.
+func (mc *MutableConfig) EffectiveAll() (map[string]Config, error) {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return mc.Config.EffectiveAll()
+}
+
 // Set sets or overwrites a value at the specified path.
-// The key's metadata must be updated: Source becomes 'ModifiedSource', and Revision is incremented.
-// Note: this method is not implemented yet and is under active development.
+// The key's metadata is updated: Source becomes "modified", and Revision is incremented.
+// If validation fails, the tree is restored to its previous state.
 func (mc *MutableConfig) Set(path KeyPath, value any) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
+	oldRoot := cloneNode(mc.root)
+
 	mc.root.Set(path, value)
 
-	if mc.validator != nil {
-		validationErrs := mc.validator.Validate(mc.root)
-		if len(validationErrs) > 0 {
-			node := mc.root.Get(path)
-			if node != nil {
-				node.Value = nil
-				// TODO: properly revert to previous state (should be implemented in TNTP-5724).
-			}
-
-			return &validationErrs[0]
-		}
+	restoreErr := mc.validateOrRestore(oldRoot)
+	if restoreErr != nil {
+		return restoreErr
 	}
 
-	node := mc.root.Get(path)
-	if node != nil {
-		node.Source = "modified"
-		// TODO: increment revision (should be implemented in TNTP-5724).
-	}
+	markModified(mc.root.Get(path))
 
 	return nil
 }
 
-// Merge merges two configurations so that all values from the new configuration
-// are added or override similar values in the current one.
-// An error may occur if the new values do not conform to the current schema.
-// Note: this method is not implemented yet and is under active development.
-func (mc *MutableConfig) Merge(other *Config) error {
-	mc.mu.Lock()
-	defer mc.mu.Unlock()
+// mergeOp represents a pending merge operation.
+type mergeOp struct {
+	path  keypath.KeyPath
+	value any
+}
 
+// materializeOps walks the other config and collects all leaf values as operations.
+func materializeOps(other *Config) ([]mergeOp, error) {
 	ctx := context.Background()
 
-	ch, err := other.Walk(ctx, nil, -1)
+	valueChan, err := other.Walk(ctx, nil, -1)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	for val := range ch {
+	var ops []mergeOp
+
+	for val := range valueChan {
 		path := val.Meta().Key
 
 		var dest any
 
 		err := val.Get(&dest)
 		if err != nil {
-			return fmt.Errorf("failed to get value at path %s: %w", path, err)
+			return nil, fmt.Errorf("failed to get value at path %s: %w", path, err)
 		}
 
-		mc.root.Set(path, dest)
+		ops = append(ops, mergeOp{path: path, value: dest})
 	}
 
-	if mc.validator != nil {
-		validationErrs := mc.validator.Validate(mc.root)
-		if len(validationErrs) > 0 {
-			return &validationErrs[0]
-		}
+	return ops, nil
+}
+
+// Merge merges two configurations so that all values from the new configuration
+// are added or override similar values in the current one.
+// If validation fails, the tree is restored to its previous state.
+func (mc *MutableConfig) Merge(other *Config) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	ops, err := materializeOps(other)
+	if err != nil {
+		return err
+	}
+
+	oldRoot := cloneNode(mc.root)
+
+	for _, mergeEntry := range ops {
+		mc.root.Set(mergeEntry.path, mergeEntry.value)
+	}
+
+	restoreErr := mc.validateOrRestore(oldRoot)
+	if restoreErr != nil {
+		return restoreErr
+	}
+
+	for _, mergeEntry := range ops {
+		markModified(mc.root.Get(mergeEntry.path))
 	}
 
 	return nil
@@ -453,52 +548,102 @@ func (mc *MutableConfig) Merge(other *Config) error {
 
 // Update merges two configurations, but applies only those values that already exist
 // in the current config. Everything else is ignored.
-// An error may occur if the new values do not match the type of the current value according to the schema.
-// Note: this method is not implemented yet and is under active development.
+// If validation fails, the tree is restored to its previous state.
 func (mc *MutableConfig) Update(other *Config) error {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
-	ctx := context.Background()
-
-	ch, err := other.Walk(ctx, nil, -1)
+	ops, err := materializeOps(other)
 	if err != nil {
 		return err
 	}
 
-	for val := range ch {
-		keyPath := val.Meta().Key
-		if mc.root.Get(keyPath) == nil {
+	oldRoot := cloneNode(mc.root)
+
+	var applied []keypath.KeyPath
+
+	for _, updateEntry := range ops {
+		if mc.root.Get(updateEntry.path) == nil {
 			continue
 		}
 
-		var dest any
+		mc.root.Set(updateEntry.path, updateEntry.value)
 
-		err := val.Get(&dest)
-		if err != nil {
-			return fmt.Errorf("failed to get value at path %s: %w", keyPath, err)
-		}
-
-		mc.root.Set(keyPath, dest)
+		applied = append(applied, updateEntry.path)
 	}
 
-	if mc.validator != nil {
-		validationErrs := mc.validator.Validate(mc.root)
-		if len(validationErrs) > 0 {
-			return &validationErrs[0]
-		}
+	restoreErr := mc.validateOrRestore(oldRoot)
+	if restoreErr != nil {
+		return restoreErr
+	}
+
+	for _, path := range applied {
+		markModified(mc.root.Get(path))
 	}
 
 	return nil
 }
 
-// Delete removes a key from the configuration.
-// Note: this method is not implemented yet and is under active development.
-func (mc *MutableConfig) Delete(_ KeyPath) bool {
+// Delete removes a key (and its entire subtree) from the configuration.
+// After removal, any ancestor maps that became empty are also removed,
+// stopping at the first non-empty ancestor.
+// Returns true if the key was found and deleted, false otherwise (idempotent).
+// If validation fails after deletion, the tree is restored and false is returned.
+func (mc *MutableConfig) Delete(path KeyPath) bool {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 
-	//nolint:godox
-	// TODO: not implemented (should be implemented in TNTP-5724).
-	return false
+	if mc.root == nil || len(path) == 0 {
+		return false
+	}
+
+	// Idempotent: missing path is not an error, just a no-op.
+	if mc.root.Get(path) == nil {
+		return false
+	}
+
+	oldRoot := cloneNode(mc.root)
+
+	// Cascade delete the target subtree, then walk back up removing
+	// any ancestors that became empty as a result.
+	for i := len(path); i > 0; i-- {
+		parentPath := path[:i-1]
+		childKey := path[i-1]
+
+		parent := mc.root.Get(parentPath)
+		if parent == nil {
+			break
+		}
+
+		if !parent.DeleteChild(childKey) {
+			break
+		}
+
+		// Stop climbing once we reach the root, or an ancestor that still
+		// holds something (remaining children, or a scalar value).
+		// The root itself is never removed.
+		if len(parentPath) == 0 || !parent.IsLeaf() || parent.Value != nil {
+			break
+		}
+	}
+
+	restoreErr := mc.validateOrRestore(oldRoot)
+
+	return restoreErr == nil
+}
+
+// validateOrRestore validates the current tree and restores the old root on failure.
+func (mc *MutableConfig) validateOrRestore(oldRoot *tree.Node) error {
+	if mc.validator == nil {
+		return nil
+	}
+
+	validationErrs := mc.validator.Validate(mc.root)
+	if len(validationErrs) > 0 {
+		mc.root = oldRoot
+
+		return &validationErrs[0]
+	}
+
+	return nil
 }

--- a/config_coverage_test.go
+++ b/config_coverage_test.go
@@ -90,6 +90,34 @@ func (v *valueChangeValidator) SchemaType() string {
 	return "value-change"
 }
 
+// minKeysValidator fails validation when number of keys is below minimum.
+type minKeysValidator struct {
+	minKeys int
+}
+
+func (m *minKeysValidator) Validate(root *tree.Node) []validator.ValidationError {
+	if root == nil {
+		return nil
+	}
+
+	if len(root.Children()) < m.minKeys {
+		return []validator.ValidationError{
+			{
+				Path:    config.NewKeyPath(""),
+				Range:   validator.NewEmptyRange(),
+				Code:    "too-few-keys",
+				Message: "too few keys",
+			},
+		}
+	}
+
+	return nil
+}
+
+func (m *minKeysValidator) SchemaType() string {
+	return "min-keys"
+}
+
 func TestConfig_Get_MissingKey(t *testing.T) {
 	t.Parallel()
 

--- a/config_test.go
+++ b/config_test.go
@@ -276,7 +276,56 @@ func TestConfig_MarshalYAML_EmptyConfig(t *testing.T) {
 	assert.Empty(t, out)
 }
 
-func TestMutableConfig_Set_NotImplemented(t *testing.T) {
+func TestMutableConfig_Set(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "original"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	err := cfg.Set(config.NewKeyPath("key"), "updated")
+	require.NoError(t, err)
+
+	var val string
+
+	meta, err := cfg.Get(config.NewKeyPath("key"), &val)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", val)
+	assert.Equal(t, "modified", meta.Source.Name)
+	assert.Equal(t, "1", string(meta.Revision))
+}
+
+func TestMutableConfig_Set_RevisionIncrement(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "v1"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	err := cfg.Set(config.NewKeyPath("key"), "v2")
+	require.NoError(t, err)
+
+	meta, _ := cfg.Stat(config.NewKeyPath("key"))
+	assert.Equal(t, "1", string(meta.Revision))
+
+	err = cfg.Set(config.NewKeyPath("key"), "v3")
+	require.NoError(t, err)
+
+	meta, _ = cfg.Stat(config.NewKeyPath("key"))
+	assert.Equal(t, "2", string(meta.Revision))
+}
+
+func TestMutableConfig_Set_NewKey(t *testing.T) {
 	t.Parallel()
 
 	data := map[string]any{}
@@ -288,14 +337,67 @@ func TestMutableConfig_Set_NotImplemented(t *testing.T) {
 	cfg, errs := builder.BuildMutable(t.Context())
 	require.Empty(t, errs)
 
-	err := cfg.Set(config.NewKeyPath("key"), "value")
+	err := cfg.Set(config.NewKeyPath("newkey"), "value")
 	require.NoError(t, err)
+
+	var val string
+
+	_, err = cfg.Get(config.NewKeyPath("newkey"), &val)
+	require.NoError(t, err)
+	assert.Equal(t, "value", val)
 }
 
-func TestMutableConfig_Merge_NotImplemented(t *testing.T) {
+func TestMutableConfig_Set_ValidationFailure_Reverts(t *testing.T) {
 	t.Parallel()
 
-	data := map[string]any{}
+	v := &valueChangeValidator{}
+	data := map[string]any{"key": "original"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(v)
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	err := cfg.Set(config.NewKeyPath("key"), "bad")
+	require.Error(t, err)
+
+	// Value should be reverted to original.
+	var val string
+
+	_, err = cfg.Get(config.NewKeyPath("key"), &val)
+	require.NoError(t, err)
+	assert.Equal(t, "original", val)
+}
+
+func TestMutableConfig_Set_ValidationFailure_RevertsNewPath(t *testing.T) {
+	t.Parallel()
+
+	v := &maxKeysValidator{maxKeys: 1}
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(v)
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	err := cfg.Set(config.NewKeyPath("secondkey"), "value")
+	require.Error(t, err)
+
+	// New key should not exist after revert.
+	_, ok := cfg.Lookup(config.NewKeyPath("secondkey"))
+	assert.False(t, ok)
+}
+
+func TestMutableConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "value"}
 	col := collectors.NewMap(data)
 	builder := config.NewBuilder()
 
@@ -308,10 +410,74 @@ func TestMutableConfig_Merge_NotImplemented(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestMutableConfig_Update_NotImplemented(t *testing.T) {
+func TestMutableConfig_Merge_Metadata(t *testing.T) {
 	t.Parallel()
 
-	data := map[string]any{}
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	otherData := map[string]any{"key": "newval", "extra": "added"}
+	col2 := collectors.NewMap(otherData)
+	builder2 := config.NewBuilder()
+
+	builder2 = builder2.AddCollector(col2)
+
+	otherCfg, errs2 := builder2.Build(t.Context())
+	require.Empty(t, errs2)
+
+	err := cfg.Merge(&otherCfg)
+	require.NoError(t, err)
+
+	meta, ok := cfg.Stat(config.NewKeyPath("key"))
+	assert.True(t, ok)
+	assert.Equal(t, "modified", meta.Source.Name)
+
+	meta, ok = cfg.Stat(config.NewKeyPath("extra"))
+	assert.True(t, ok)
+	assert.Equal(t, "modified", meta.Source.Name)
+}
+
+func TestMutableConfig_Merge_ValidationFailure_Reverts(t *testing.T) {
+	t.Parallel()
+
+	v := &maxKeysValidator{maxKeys: 1}
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(v)
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	otherData := map[string]any{"newkey": "newvalue"}
+	col2 := collectors.NewMap(otherData)
+	builder2 := config.NewBuilder()
+
+	builder2 = builder2.AddCollector(col2)
+
+	otherCfg, errs2 := builder2.Build(t.Context())
+	require.Empty(t, errs2)
+
+	err := cfg.Merge(&otherCfg)
+	require.Error(t, err)
+
+	// newkey should not exist after revert.
+	_, ok := cfg.Lookup(config.NewKeyPath("newkey"))
+	assert.False(t, ok)
+}
+
+func TestMutableConfig_Update(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "value"}
 	col := collectors.NewMap(data)
 	builder := config.NewBuilder()
 
@@ -324,10 +490,73 @@ func TestMutableConfig_Update_NotImplemented(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestMutableConfig_Delete_NotImplemented(t *testing.T) {
+func TestMutableConfig_Update_Metadata(t *testing.T) {
 	t.Parallel()
 
-	data := map[string]any{}
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	otherData := map[string]any{"key": "updated"}
+	col2 := collectors.NewMap(otherData)
+	builder2 := config.NewBuilder()
+
+	builder2 = builder2.AddCollector(col2)
+
+	otherCfg, errs2 := builder2.Build(t.Context())
+	require.Empty(t, errs2)
+
+	err := cfg.Update(&otherCfg)
+	require.NoError(t, err)
+
+	meta, ok := cfg.Stat(config.NewKeyPath("key"))
+	assert.True(t, ok)
+	assert.Equal(t, "modified", meta.Source.Name)
+}
+
+func TestMutableConfig_Update_ValidationFailure_Reverts(t *testing.T) {
+	t.Parallel()
+
+	v := &valueChangeValidator{}
+	data := map[string]any{"key": "original"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(v)
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	otherData := map[string]any{"key": "newvalue"}
+	col2 := collectors.NewMap(otherData)
+	builder2 := config.NewBuilder()
+
+	builder2 = builder2.AddCollector(col2)
+
+	otherCfg, errs2 := builder2.Build(t.Context())
+	require.Empty(t, errs2)
+
+	err := cfg.Update(&otherCfg)
+	require.Error(t, err)
+
+	// Value should be reverted to original.
+	var val string
+
+	_, err = cfg.Get(config.NewKeyPath("key"), &val)
+	require.NoError(t, err)
+	assert.Equal(t, "original", val)
+}
+
+func TestMutableConfig_Delete_ExistingKey(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "value", "other": "data"}
 	col := collectors.NewMap(data)
 	builder := config.NewBuilder()
 
@@ -337,5 +566,305 @@ func TestMutableConfig_Delete_NotImplemented(t *testing.T) {
 	require.Empty(t, errs)
 
 	deleted := cfg.Delete(config.NewKeyPath("key"))
+	assert.True(t, deleted)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("key"))
+	assert.False(t, ok)
+
+	// Other key should still exist.
+	_, ok = cfg.Lookup(config.NewKeyPath("other"))
+	assert.True(t, ok)
+}
+
+func TestMutableConfig_Delete_MissingKey(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	deleted := cfg.Delete(config.NewKeyPath("nonexistent"))
 	assert.False(t, deleted)
+}
+
+func TestMutableConfig_Delete_EmptyPath(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	deleted := cfg.Delete(config.NewKeyPath(""))
+	assert.False(t, deleted)
+}
+
+func TestMutableConfig_Delete_NestedKey(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"server": map[string]any{
+			"host": "localhost",
+			"port": 8080,
+		},
+	}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	deleted := cfg.Delete(config.NewKeyPath("server/host"))
+	assert.True(t, deleted)
+
+	_, ok := cfg.Lookup(config.NewKeyPath("server/host"))
+	assert.False(t, ok)
+
+	// server/port should still exist.
+	var port int
+
+	_, err := cfg.Get(config.NewKeyPath("server/port"), &port)
+	require.NoError(t, err)
+	assert.Equal(t, 8080, port)
+}
+
+func TestMutableConfig_Delete_ValidationFailure_Reverts(t *testing.T) {
+	t.Parallel()
+
+	// minKeysValidator requires at least 2 keys. Start with 2 keys (build passes).
+	// Deleting one would drop to 1 key, failing validation, so tree should be restored.
+	v := &minKeysValidator{minKeys: 2}
+	data := map[string]any{"key": "value", "other": "data"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(v)
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	deleted := cfg.Delete(config.NewKeyPath("key"))
+	assert.False(t, deleted)
+
+	// Key should still exist after revert.
+	_, ok := cfg.Lookup(config.NewKeyPath("key"))
+	assert.True(t, ok)
+}
+
+func TestMutableConfig_Delete_Cascade(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"server": map[string]any{
+			"host": "localhost",
+			"port": 8080,
+			"tls": map[string]any{
+				"cert": "a.pem",
+				"key":  "a.key",
+			},
+		},
+	}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	// Deleting the "server" map should remove all descendants.
+	deleted := cfg.Delete(config.NewKeyPath("server"))
+	assert.True(t, deleted)
+
+	gone := []string{
+		"server",
+		"server/host",
+		"server/port",
+		"server/tls",
+		"server/tls/cert",
+		"server/tls/key",
+	}
+	for _, path := range gone {
+		_, ok := cfg.Lookup(config.NewKeyPath(path))
+		assert.Falsef(t, ok, "expected %q to be gone", path)
+	}
+}
+
+func TestMutableConfig_Delete_CleanupEmptyParents(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"groups": map[string]any{
+			"g1": map[string]any{
+				"replicasets": map[string]any{
+					"r1": map[string]any{
+						"instances": map[string]any{
+							"i1": map[string]any{"role": "leader"},
+						},
+					},
+				},
+			},
+			"g2": map[string]any{"keep": "me"},
+		},
+	}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	// Deleting the only instance under g1 should collapse all empty
+	// ancestors up to and including "groups/g1", but stop at "groups"
+	// because g2 keeps it non-empty.
+	deleted := cfg.Delete(config.NewKeyPath("groups/g1/replicasets/r1/instances/i1"))
+	assert.True(t, deleted)
+
+	for _, path := range []string{
+		"groups/g1/replicasets/r1/instances/i1",
+		"groups/g1/replicasets/r1/instances",
+		"groups/g1/replicasets/r1",
+		"groups/g1/replicasets",
+		"groups/g1",
+	} {
+		_, ok := cfg.Lookup(config.NewKeyPath(path))
+		assert.Falsef(t, ok, "expected %q to be cleaned up", path)
+	}
+
+	// Sibling and the first non-empty ancestor must survive.
+	_, ok := cfg.Lookup(config.NewKeyPath("groups"))
+	assert.True(t, ok, "groups should remain because g2 still exists under it")
+
+	var keep string
+
+	_, err := cfg.Get(config.NewKeyPath("groups/g2/keep"), &keep)
+	require.NoError(t, err)
+	assert.Equal(t, "me", keep)
+}
+
+func TestMutableConfig_Delete_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"a": map[string]any{"b": "c"}}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	// First delete succeeds and cascades.
+	assert.True(t, cfg.Delete(config.NewKeyPath("a/b")))
+
+	// Re-delete is a no-op, returns false, does not panic.
+	assert.False(t, cfg.Delete(config.NewKeyPath("a/b")))
+	assert.False(t, cfg.Delete(config.NewKeyPath("a")))
+	assert.False(t, cfg.Delete(config.NewKeyPath("never-existed")))
+}
+
+func TestMutableConfig_Effective_AfterMutation(t *testing.T) {
+	t.Parallel()
+
+	build := func(t *testing.T) *config.MutableConfig {
+		t.Helper()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"replication": map[string]any{"failover": "manual"},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test"))
+
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.BuildMutable(t.Context())
+		require.Empty(t, errs)
+
+		return &cfg
+	}
+
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	t.Run("Set on parent group propagates to Effective", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := build(t)
+
+		// Override at the global level — must be visible through Effective on the leaf.
+		require.NoError(t, cfg.Set(config.NewKeyPath("replication/failover"), "election"))
+
+		eff, err := cfg.Effective(leafPath)
+		require.NoError(t, err)
+
+		var failover string
+
+		_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+		require.NoError(t, err)
+		assert.Equal(t, "election", failover)
+	})
+
+	t.Run("Merge propagates to Effective", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := build(t)
+
+		patchBuilder := config.NewBuilder()
+
+		patchBuilder = patchBuilder.AddCollector(collectors.NewMap(map[string]any{
+			"replication": map[string]any{"failover": "supervised"},
+		}))
+
+		patch, errs := patchBuilder.Build(t.Context())
+		require.Empty(t, errs)
+		require.NoError(t, cfg.Merge(&patch))
+
+		eff, err := cfg.Effective(leafPath)
+		require.NoError(t, err)
+
+		var failover string
+
+		_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+		require.NoError(t, err)
+		assert.Equal(t, "supervised", failover)
+	})
+
+	t.Run("Delete propagates to Effective", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := build(t)
+
+		require.True(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+		eff, err := cfg.Effective(leafPath)
+		require.NoError(t, err)
+
+		_, ok := eff.Lookup(config.NewKeyPath("replication/failover"))
+		assert.False(t, ok, "Effective should not see a key removed via Delete")
+	})
 }

--- a/example_config_test.go
+++ b/example_config_test.go
@@ -307,3 +307,117 @@ func Example_effectiveAll() {
 	// groups/storages/replicasets/s-001/instances/s-001-a: listen=127.0.0.1:3301 failover=manual
 	// groups/storages/replicasets/s-001/instances/s-001-b: listen=127.0.0.1:3302 failover=manual
 }
+
+// Example_mutableConfig demonstrates MutableConfig with Set, Merge, and Update
+// methods for modifying configuration at runtime.
+func Example_mutableConfig() {
+	data := map[string]any{
+		"server": map[string]any{
+			"host": "localhost",
+			"port": 8080,
+		},
+		"debug": false,
+	}
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(data).WithName("config"))
+
+	cfg, errs := builder.BuildMutable(context.Background())
+	if len(errs) > 0 {
+		fmt.Printf("Build errors: %v\n", errs)
+		return
+	}
+
+	// Set overwrites a single value.
+	err := cfg.Set(config.NewKeyPath("server/port"), 9090)
+	if err != nil {
+		fmt.Printf("Set error: %v\n", err)
+		return
+	}
+
+	var port int
+
+	_, err = cfg.Get(config.NewKeyPath("server/port"), &port)
+	if err != nil {
+		fmt.Printf("Get error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Port after Set: %d\n", port)
+
+	// Merge adds all values from another Config (overrides existing keys).
+	overrideData := map[string]any{
+		"debug": true,
+	}
+
+	overrideBuilder := config.NewBuilder()
+
+	overrideBuilder = overrideBuilder.AddCollector(collectors.NewMap(overrideData))
+
+	overrideCfg, errs := overrideBuilder.Build(context.Background())
+	if len(errs) > 0 {
+		fmt.Printf("Build errors: %v\n", errs)
+		return
+	}
+
+	err = cfg.Merge(&overrideCfg)
+	if err != nil {
+		fmt.Printf("Merge error: %v\n", err)
+		return
+	}
+
+	var debug bool
+
+	_, err = cfg.Get(config.NewKeyPath("debug"), &debug)
+	if err != nil {
+		fmt.Printf("Get error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Debug after Merge: %v\n", debug)
+
+	// Update only modifies keys that already exist in the config.
+	updateData := map[string]any{
+		"server": map[string]any{
+			"host": "0.0.0.0",
+		},
+		"new_key": "ignored",
+	}
+
+	updateBuilder := config.NewBuilder()
+
+	updateBuilder = updateBuilder.AddCollector(collectors.NewMap(updateData))
+
+	updateCfg, errs := updateBuilder.Build(context.Background())
+	if len(errs) > 0 {
+		fmt.Printf("Build errors: %v\n", errs)
+		return
+	}
+
+	err = cfg.Update(&updateCfg)
+	if err != nil {
+		fmt.Printf("Update error: %v\n", err)
+		return
+	}
+
+	var host string
+
+	_, err = cfg.Get(config.NewKeyPath("server/host"), &host)
+	if err != nil {
+		fmt.Printf("Get error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Host after Update: %s\n", host)
+
+	// Verify that new_key was not added by Update.
+	_, ok := cfg.Lookup(config.NewKeyPath("new_key"))
+	fmt.Printf("new_key exists: %v\n", ok)
+
+	// Output:
+	// Port after Set: 9090
+	// Debug after Merge: true
+	// Host after Update: 0.0.0.0
+	// new_key exists: false
+}

--- a/inheritance.go
+++ b/inheritance.go
@@ -180,10 +180,15 @@ func cloneNode(node *tree.Node) *tree.Node {
 	clone.Value = node.Value
 	clone.Source = node.Source
 	clone.Revision = node.Revision
+	clone.Range = node.Range
 	clone.SetAnnotation(node.Annotation())
 
 	if node.IsArray() {
 		clone.MarkArray()
+	}
+
+	if node.OrderSet() {
+		clone.SetOrderSet(true)
 	}
 
 	for _, key := range node.ChildrenKeys() {


### PR DESCRIPTION
Implement complete mutable configuration API with thread-safe operations and validation rollback support.

All modifications now properly validate and restore previous state if validation fails, ensuring atomicity of configuration changes.

Part of TNTP-5724