### PR TITLE
config: marshal YAML preserving order, style, comments

### DIFF
--- a/collectors/yaml.go
+++ b/collectors/yaml.go
@@ -72,36 +72,50 @@ func (y YamlFormat) Parse() (*tree.Node, error) {
 
 	root := tree.New()
 
-	flattenYamlIntoTree(root, node, config.NewKeyPath(""))
+	flattenYamlIntoTree(root, nil, node, config.NewKeyPath(""))
 
 	return root, nil
 }
 
-func flattenYamlIntoTree(node *tree.Node, yamlNode yaml.Node,
+func flattenYamlIntoTree(node *tree.Node, key *yaml.Node, yamlNode yaml.Node,
 	prefix config.KeyPath,
 ) {
 	switch yamlNode.Kind {
 	case yaml.DocumentNode:
 		for _, child := range yamlNode.Content {
-			flattenYamlIntoTree(node, *child, prefix)
+			flattenYamlIntoTree(node, nil, *child, prefix)
 		}
 	case yaml.MappingNode:
 		if len(yamlNode.Content) == 0 {
 			node.Set(prefix, map[string]any{})
 
+			if target := node.Get(prefix); target != nil {
+				yamlNodeCopy := yamlNode
+				target.SetAnnotation(config.YAMLAnnotation{Key: key, Val: &yamlNodeCopy})
+			}
+
 			return
 		}
 
+		// Ensure the mapping node exists so we can attach the annotation.
+		if len(prefix) > 0 && node.Get(prefix) == nil {
+			node.Set(prefix, nil)
+
+			node.Get(prefix).Value = nil
+		}
+
+		if target := node.Get(prefix); target != nil {
+			yamlNodeCopy := yamlNode
+			target.SetAnnotation(config.YAMLAnnotation{Key: key, Val: &yamlNodeCopy})
+		}
+
 		for i := 0; i < len(yamlNode.Content); i += 2 {
-			key := yamlNode.Content[i]
+			k := yamlNode.Content[i]
 			value := yamlNode.Content[i+1]
 
-			// key.HeadComment - over the line.
-			// key.LineComment - in the line.
+			newPrefix := prefix.Append(k.Value)
 
-			newPrefix := prefix.Append(key.Value)
-
-			flattenYamlIntoTree(node, *value, newPrefix)
+			flattenYamlIntoTree(node, k, *value, newPrefix)
 		}
 	case yaml.SequenceNode:
 		// Ensure the array node exists even for empty sequences.
@@ -112,23 +126,30 @@ func flattenYamlIntoTree(node *tree.Node, yamlNode yaml.Node,
 		arrNode := node.Get(prefix)
 		arrNode.MarkArray()
 
+		yamlNodeCopy := yamlNode
+		arrNode.SetAnnotation(config.YAMLAnnotation{Key: key, Val: &yamlNodeCopy})
+
 		for i, item := range yamlNode.Content {
 			newPrefix := prefix.Append(strconv.Itoa(i))
 
-			flattenYamlIntoTree(node, *item, newPrefix)
+			flattenYamlIntoTree(node, nil, *item, newPrefix)
 		}
 	case yaml.AliasNode:
 		// Field `Value` contains name of the anchor.
 		// Field `Alias` contains pointer to the anchor.
-		flattenYamlIntoTree(node, *yamlNode.Alias, prefix)
+		flattenYamlIntoTree(node, key, *yamlNode.Alias, prefix)
 	case yaml.ScalarNode:
 		node.Set(prefix, resolveYamlScalar(yamlNode))
 
-		if n := node.Get(prefix); n != nil {
-			n.Range = tree.Range{
+		target := node.Get(prefix)
+		if target != nil {
+			target.Range = tree.Range{
 				Start: tree.Position{Line: yamlNode.Line, Column: yamlNode.Column},
 				End:   tree.Position{Line: yamlNode.Line, Column: yamlNode.Column},
 			}
+
+			yamlNodeCopy := yamlNode
+			target.SetAnnotation(config.YAMLAnnotation{Key: key, Val: &yamlNodeCopy})
 		}
 	default:
 	}

--- a/config.go
+++ b/config.go
@@ -314,21 +314,6 @@ func (c *Config) EffectiveAll() (map[string]Config, error) {
 	return result, nil
 }
 
-// String returns a string with the current representation of the configuration according to the YAML format.
-func (c *Config) String() string {
-	//nolint:godox
-	// TODO: implement YAML serialization.
-	return ""
-}
-
-// MarshalYAML serializes the Config object into YAML format.
-// Thanks to key order preservation, the resulting YAML will have a predictable and stable structure.
-func (c *Config) MarshalYAML() ([]byte, error) {
-	//nolint:godox
-	// TODO: implement YAML marshaling.
-	return nil, nil
-}
-
 // collectLeafEntities recursively finds all leaf entities in the hierarchy
 // and resolves their effective config.
 //

--- a/config_test.go
+++ b/config_test.go
@@ -244,7 +244,7 @@ func TestConfig_Walk_FromSubPath(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
-func TestConfig_String_ReturnsEmpty(t *testing.T) {
+func TestConfig_String_EmptyConfig(t *testing.T) {
 	t.Parallel()
 
 	data := map[string]any{}
@@ -259,7 +259,7 @@ func TestConfig_String_ReturnsEmpty(t *testing.T) {
 	assert.Empty(t, cfg.String())
 }
 
-func TestConfig_MarshalYAML_ReturnsNil(t *testing.T) {
+func TestConfig_MarshalYAML_EmptyConfig(t *testing.T) {
 	t.Parallel()
 
 	data := map[string]any{}
@@ -271,9 +271,9 @@ func TestConfig_MarshalYAML_ReturnsNil(t *testing.T) {
 	cfg, errs := builder.Build(t.Context())
 	require.Empty(t, errs)
 
-	bytes, err := cfg.MarshalYAML()
+	out, err := cfg.MarshalYAML()
 	require.NoError(t, err)
-	assert.Nil(t, bytes)
+	assert.Empty(t, out)
 }
 
 func TestMutableConfig_Set_NotImplemented(t *testing.T) {

--- a/inheritance.go
+++ b/inheritance.go
@@ -180,6 +180,7 @@ func cloneNode(node *tree.Node) *tree.Node {
 	clone.Value = node.Value
 	clone.Source = node.Source
 	clone.Revision = node.Revision
+	clone.SetAnnotation(node.Annotation())
 
 	if node.IsArray() {
 		clone.MarkArray()

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,306 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/tarantool/go-config/tree"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	yamlIndent      = 2
+	yamlFloatTag    = "!!float"
+	yamlNullTag     = "!!null"
+	yamlStringTag   = "!!str"
+	modifiedSrcName = "modified"
+)
+
+// YAMLAnnotation captures the YAML-specific information needed to faithfully
+// re-emit a tree node: scalar style, comments, and tag. It is attached to
+// tree.Node by the YAML collector and consumed by Config.MarshalYAML.
+//
+// Key holds the *yaml.Node corresponding to this entry's key in its parent
+// mapping (nil for sequence items, document roots, and programmatically-added
+// nodes). Val holds the *yaml.Node corresponding to this node's value.
+type YAMLAnnotation struct {
+	Key *yaml.Node
+	Val *yaml.Node
+}
+
+// String returns the configuration serialized as YAML.
+// Returns an empty string if marshaling fails.
+func (c *Config) String() string {
+	out, err := c.MarshalYAML()
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+// MarshalYAML serializes the Config as YAML.
+//
+// Key insertion order is preserved across maps. For nodes that came from a
+// YAML source and have not been mutated, the original scalar style and the
+// surrounding head/line/foot comments are preserved. Programmatically-added
+// keys are emitted with default style and no comments.
+func (c *Config) MarshalYAML() ([]byte, error) {
+	if c.root == nil || c.root.IsLeaf() && c.root.Value == nil && len(c.root.ChildrenKeys()) == 0 {
+		return []byte{}, nil
+	}
+
+	yamlNode, err := nodeToYAML(c.root)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(yamlIndent)
+
+	encErr := enc.Encode(yamlNode)
+	if encErr != nil {
+		return nil, fmt.Errorf("yaml encode: %w", encErr)
+	}
+
+	closeErr := enc.Close()
+	if closeErr != nil {
+		return nil, fmt.Errorf("yaml encode close: %w", closeErr)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// yamlAnnotation extracts a YAMLAnnotation from a tree.Node, or returns
+// the zero value when no YAML annotation is attached.
+func yamlAnnotation(node *tree.Node) YAMLAnnotation {
+	if node == nil {
+		return YAMLAnnotation{Key: nil, Val: nil}
+	}
+
+	annotation, ok := node.Annotation().(YAMLAnnotation)
+	if !ok {
+		return YAMLAnnotation{Key: nil, Val: nil}
+	}
+
+	return annotation
+}
+
+// nodeToYAML converts a tree.Node into a *yaml.Node.
+// When the tree node was unchanged since parsing from YAML, the original
+// scalar style and surrounding comments are reused.
+func nodeToYAML(node *tree.Node) (*yaml.Node, error) {
+	switch {
+	case node == nil:
+		return newScalarNode(yamlNullTag, ""), nil
+	case node.IsArray():
+		return arrayNodeToYAML(node)
+	case node.IsLeaf():
+		return scalarNodeToYAML(node)
+	default:
+		return mappingNodeToYAML(node)
+	}
+}
+
+// scalarNodeToYAML emits a leaf as a scalar yaml.Node, reusing style/comments
+// from the original annotation when the value has not been modified.
+func scalarNodeToYAML(node *tree.Node) (*yaml.Node, error) {
+	annotation := yamlAnnotation(node)
+	mutated := node.Source == modifiedSrcName
+
+	if annotation.Val != nil && !mutated {
+		clone := cloneScalarYAMLNode(annotation.Val)
+
+		return clone, nil
+	}
+
+	out := newScalarNode("", "")
+
+	encErr := out.Encode(node.Value)
+	if encErr != nil {
+		return nil, fmt.Errorf("encode scalar: %w", encErr)
+	}
+
+	// Encode emits canonical YAML for ordinary scalars but produces an empty
+	// Value for Inf and NaN — the fallback below ensures we always emit
+	// the canonical YAML form for those special floats.
+	if out.Kind == yaml.ScalarNode && out.Value == "" {
+		fillSpecialFloat(out, node.Value)
+	}
+
+	// Carry over comments from the annotation even when the value is mutated.
+	if annotation.Val != nil {
+		out.HeadComment = annotation.Val.HeadComment
+		out.LineComment = annotation.Val.LineComment
+		out.FootComment = annotation.Val.FootComment
+	}
+
+	return out, nil
+}
+
+// fillSpecialFloat fills out.Value/Tag for Inf and NaN values, which yaml.Node.Encode
+// leaves with an empty Value.
+func fillSpecialFloat(out *yaml.Node, value any) {
+	floatVal, ok := value.(float64)
+	if !ok {
+		return
+	}
+
+	switch {
+	case math.IsNaN(floatVal):
+		out.Value = ".nan"
+		out.Tag = yamlFloatTag
+	case math.IsInf(floatVal, 1):
+		out.Value = ".inf"
+		out.Tag = yamlFloatTag
+	case math.IsInf(floatVal, -1):
+		out.Value = "-.inf"
+		out.Tag = yamlFloatTag
+	}
+}
+
+// mappingNodeToYAML emits a mapping yaml.Node, walking children in tree order.
+func mappingNodeToYAML(node *tree.Node) (*yaml.Node, error) {
+	out := newCollectionNode(yaml.MappingNode)
+
+	if annotation := yamlAnnotation(node); annotation.Val != nil {
+		out.Style = annotation.Val.Style
+		out.HeadComment = annotation.Val.HeadComment
+		out.LineComment = annotation.Val.LineComment
+		out.FootComment = annotation.Val.FootComment
+	}
+
+	for _, key := range node.ChildrenKeys() {
+		child := node.Child(key)
+		if child == nil {
+			continue
+		}
+
+		keyNode := keyYAMLNode(key, child)
+
+		valNode, err := nodeToYAML(child)
+		if err != nil {
+			return nil, err
+		}
+
+		out.Content = append(out.Content, keyNode, valNode)
+	}
+
+	return out, nil
+}
+
+// arrayNodeToYAML emits a sequence yaml.Node, walking children in index order.
+func arrayNodeToYAML(node *tree.Node) (*yaml.Node, error) {
+	out := newCollectionNode(yaml.SequenceNode)
+
+	if annotation := yamlAnnotation(node); annotation.Val != nil {
+		out.Style = annotation.Val.Style
+		out.HeadComment = annotation.Val.HeadComment
+		out.LineComment = annotation.Val.LineComment
+		out.FootComment = annotation.Val.FootComment
+	}
+
+	for _, key := range orderedArrayKeys(node) {
+		child := node.Child(key)
+		if child == nil {
+			continue
+		}
+
+		valNode, err := nodeToYAML(child)
+		if err != nil {
+			return nil, err
+		}
+
+		out.Content = append(out.Content, valNode)
+	}
+
+	return out, nil
+}
+
+// orderedArrayKeys returns the keys of an array node in numeric order, then
+// any non-numeric keys in their existing order. Non-numeric keys are unusual
+// for arrays but we accept them to be defensive.
+func orderedArrayKeys(node *tree.Node) []string {
+	keys := node.ChildrenKeys()
+
+	indexed := make([]string, 0, len(keys))
+	other := make([]string, 0)
+
+	for _, key := range keys {
+		_, atoiErr := strconv.Atoi(key)
+		if atoiErr == nil {
+			indexed = append(indexed, key)
+		} else {
+			other = append(other, key)
+		}
+	}
+
+	return append(indexed, other...)
+}
+
+// keyYAMLNode returns a yaml.Node to use as the key in a mapping.
+// When the child carries a YAML annotation with the original key node, that
+// node's style and comments are reused.
+func keyYAMLNode(key string, child *tree.Node) *yaml.Node {
+	if annotation := yamlAnnotation(child); annotation.Key != nil {
+		return cloneScalarYAMLNode(annotation.Key)
+	}
+
+	return newScalarNode(yamlStringTag, key)
+}
+
+// cloneScalarYAMLNode returns a copy of the given scalar yaml.Node with
+// Content/Anchor/Alias stripped — those are not meaningful on the cloned
+// scalar value or key.
+func cloneScalarYAMLNode(src *yaml.Node) *yaml.Node {
+	clone := *src
+
+	clone.Content = nil
+	clone.Anchor = ""
+	clone.Alias = nil
+
+	return &clone
+}
+
+// newScalarNode constructs a fully-zeroed scalar yaml.Node with the given
+// tag and value. Centralising construction satisfies exhaustruct without
+// scattering nolint directives.
+func newScalarNode(tag, value string) *yaml.Node {
+	return &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Style:       0,
+		Tag:         tag,
+		Value:       value,
+		Anchor:      "",
+		Alias:       nil,
+		Content:     nil,
+		HeadComment: "",
+		LineComment: "",
+		FootComment: "",
+		Line:        0,
+		Column:      0,
+	}
+}
+
+// newCollectionNode constructs a fully-zeroed yaml.Node of MappingNode or
+// SequenceNode kind.
+func newCollectionNode(kind yaml.Kind) *yaml.Node {
+	return &yaml.Node{
+		Kind:        kind,
+		Style:       0,
+		Tag:         "",
+		Value:       "",
+		Anchor:      "",
+		Alias:       nil,
+		Content:     nil,
+		HeadComment: "",
+		LineComment: "",
+		FootComment: "",
+		Line:        0,
+		Column:      0,
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,213 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/collectors"
+)
+
+// buildFromYAML writes data to a temp file and returns a built MutableConfig.
+func buildFromYAML(t *testing.T, data string) *config.MutableConfig {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+
+	col, err := collectors.NewSource(t.Context(), collectors.NewFile(path), collectors.NewYamlFormat())
+	require.NoError(t, err)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	return &cfg
+}
+
+// TestMarshal_RoundTrip pins that an unmutated config marshals back to the
+// canonical re-emission of the input — i.e., parsing then marshaling without
+// any mutation does not lose key order or comments.
+func TestMarshal_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	input := `# top-level head
+server:
+    host: localhost
+    port: 8080
+    tls:
+        cert: a.pem
+        key: a.key
+client:
+    name: example
+    timeout: 30
+`
+
+	cfg := buildFromYAML(t, input)
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	// Round-trip: re-parsing the output reproduces the same key order and values.
+	got := buildFromYAML(t, string(out))
+
+	for path, want := range map[string]any{
+		"server/host":     "localhost",
+		"server/port":     int64(8080),
+		"server/tls/cert": "a.pem",
+		"server/tls/key":  "a.key",
+		"client/name":     "example",
+		"client/timeout":  int64(30),
+	} {
+		var actual any
+
+		_, err := got.Get(config.NewKeyPath(path), &actual)
+		require.NoErrorf(t, err, "path %s missing after round-trip", path)
+		assert.Equalf(t, want, actual, "path %s", path)
+	}
+
+	// Order is preserved at every level.
+	assertKeyOrder(t, got, "", []string{"server", "client"})
+	assertKeyOrder(t, got, "server", []string{"host", "port", "tls"})
+	assertKeyOrder(t, got, "server/tls", []string{"cert", "key"})
+	assertKeyOrder(t, got, "client", []string{"name", "timeout"})
+}
+
+// TestMarshal_PreservesOrder pins that, after Set of a new key, existing
+// keys keep their source order and the new key is appended.
+func TestMarshal_PreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	input := `zeta: 1
+alpha: 2
+mu: 3
+`
+
+	cfg := buildFromYAML(t, input)
+
+	require.NoError(t, cfg.Set(config.NewKeyPath("inserted"), "x"))
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	got := buildFromYAML(t, string(out))
+
+	assertKeyOrder(t, got, "", []string{"zeta", "alpha", "mu", "inserted"})
+}
+
+// TestMarshal_PreservesComments pins that, after a Set on one leaf, head/line/foot
+// comments on neighboring nodes survive the marshal.
+func TestMarshal_PreservesComments(t *testing.T) {
+	t.Parallel()
+
+	input := `# header for alpha
+alpha: 1 # inline on alpha
+# header for beta
+beta: 2
+# header for gamma
+gamma: 3
+`
+
+	cfg := buildFromYAML(t, input)
+
+	// Mutate beta. Neighbor comments must survive.
+	require.NoError(t, cfg.Set(config.NewKeyPath("beta"), int64(20)))
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	str := string(out)
+
+	for _, fragment := range []string{
+		"# header for alpha",
+		"# inline on alpha",
+		"# header for beta",
+		"# header for gamma",
+	} {
+		assert.Containsf(t, str, fragment, "expected %q in output:\n%s", fragment, str)
+	}
+}
+
+// TestMarshal_PreservesScalarStyle pins that single-quoted, double-quoted, and
+// unquoted scalars from the source round-trip with the same style on
+// un-mutated leaves.
+func TestMarshal_PreservesScalarStyle(t *testing.T) {
+	t.Parallel()
+
+	input := `single: 'foo'
+double: "bar"
+plain: baz
+literal: |
+  line one
+  line two
+`
+
+	cfg := buildFromYAML(t, input)
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	str := string(out)
+
+	// Single-quoted style retained.
+	assert.Containsf(t, str, "'foo'", "single-quoted style lost:\n%s", str)
+	// Double-quoted style retained.
+	assert.Containsf(t, str, `"bar"`, "double-quoted style lost:\n%s", str)
+	// Plain remains plain — i.e., no quotes around baz.
+	assert.Regexpf(t, `(?m)^plain: baz\b`, str, "plain style lost:\n%s", str)
+	// Literal block style retained.
+	assert.Containsf(t, str, "literal: |", "literal block style lost:\n%s", str)
+}
+
+func assertKeyOrder(t *testing.T, cfg *config.MutableConfig, path string, want []string) {
+	t.Helper()
+
+	keys := childKeysAt(t, cfg, path)
+	assert.Equalf(t, want, keys, "child key order at %q", path)
+}
+
+// childKeysAt returns the immediate child keys at the given path, in tree order.
+// Walk emits leaves only, so we descend the entire subtree and collect the
+// segment immediately following `path` from each leaf's full key path.
+func childKeysAt(t *testing.T, cfg *config.MutableConfig, path string) []string {
+	t.Helper()
+
+	values, err := cfg.Walk(t.Context(), config.NewKeyPath(path), -1)
+	require.NoError(t, err)
+
+	var prefixLen int
+	if path != "" {
+		prefixLen = len(strings.Split(path, "/"))
+	}
+
+	var keys []string
+
+	for v := range values {
+		segments := v.Meta().Key
+		if len(segments) <= prefixLen {
+			continue
+		}
+
+		keys = appendUnique(keys, segments[prefixLen])
+	}
+
+	return keys
+}
+
+func appendUnique(s []string, v string) []string {
+	if slices.Contains(s, v) {
+		return s
+	}
+
+	return append(s, v)
+}

--- a/merge.go
+++ b/merge.go
@@ -59,6 +59,12 @@ func MergeCollectorWithMerger(ctx context.Context, root *tree.Node, col Collecto
 			errs = append(errs, fmt.Errorf("merge value at %s: %w", meta.Key.String(), err))
 			continue
 		}
+
+		// If the source value carries a format-specific annotation
+		// (e.g., the YAML node it was parsed from), forward it onto
+		// the destination tree node so that marshalers can reproduce
+		// scalar style and comments.
+		copyAnnotation(root, meta.Key, val)
 	}
 
 	err := mergeCtx.ApplyOrdering(root)
@@ -144,6 +150,27 @@ func mergeNodeValue(node *tree.Node, value any, col Collector) {
 	// Update node metadata.
 	node.Source = col.Name()
 	node.Revision = string(col.Revision())
+}
+
+// copyAnnotation forwards the format-specific annotation from a source Value
+// onto the destination tree node at path, when the source exposes one.
+func copyAnnotation(root *tree.Node, path keypath.KeyPath, src Value) {
+	carrier, ok := src.(interface{ Annotation() any })
+	if !ok {
+		return
+	}
+
+	anno := carrier.Annotation()
+	if anno == nil {
+		return
+	}
+
+	dest := root.Get(path)
+	if dest == nil {
+		return
+	}
+
+	dest.SetAnnotation(anno)
 }
 
 // mergeMapIntoNode merges a map into a node's children recursively.

--- a/tree/node.go
+++ b/tree/node.go
@@ -24,6 +24,12 @@ type Node struct {
 	// Range indicates the position in source file where this node was defined.
 	Range Range
 
+	// annotation holds an opaque, format-specific representation of this node
+	// (e.g., the original *yaml.Node it came from). It is preserved across
+	// cloning and read by format-aware marshalers to reproduce style and
+	// comments. The tree package treats it as opaque.
+	annotation any
+
 	// isArray indicates that this node represents a YAML sequence (array).
 	// Children are indexed by "0", "1", "2", etc.
 	isArray bool
@@ -43,10 +49,25 @@ func New() *Node {
 		Revision: "",
 		Range:    Range{Start: Position{Line: 0, Column: 0}, End: Position{Line: 0, Column: 0}},
 
-		isArray:  false,
-		children: nil,
-		orderSet: false,
+		annotation: nil,
+		isArray:    false,
+		children:   nil,
+		orderSet:   false,
 	}
+}
+
+// Annotation returns the opaque annotation attached to this node, if any.
+// Format-specific collectors may set this to retain information (such as
+// comments and scalar style) that the tree itself does not model.
+func (n *Node) Annotation() any {
+	return n.annotation
+}
+
+// SetAnnotation attaches an opaque annotation to this node.
+// The tree package does not interpret it; readers (e.g., a YAML marshaler)
+// type-assert to recover format-specific data.
+func (n *Node) SetAnnotation(a any) {
+	n.annotation = a
 }
 
 // IsLeaf returns true if the node has no children.

--- a/tree/value.go
+++ b/tree/value.go
@@ -65,6 +65,18 @@ func (v *valueImpl) Meta() meta.Info {
 	}
 }
 
+// Annotation returns the opaque annotation attached to the underlying tree
+// node, if any. Code that consumes Values can type-assert to discover this
+// method when it needs to forward format-specific metadata (such as YAML
+// comment and style information) through the merge pipeline.
+func (v *valueImpl) Annotation() any {
+	if v.node == nil {
+		return nil
+	}
+
+	return v.node.Annotation()
+}
+
 // nodeToValue converts a tree node into a generic Go value.
 // If the node is a leaf (no children), returns node.Value (which may be a slice, map, or primitive).
 // For array nodes, builds a []any from children in order.


### PR DESCRIPTION
Implement Config.MarshalYAML and Config.String. The previous stubs returned empty/nil; tt's write paths (Publish, ReplaceInstanceConfig, cluster show) silently overwrote hand-edited YAML and lost comments and quoting. The fix carries the original *yaml.Node through the merge pipeline.

Part of TNTP-5724