### PR TITLE
chore: make autosync commits to be readable again

### DIFF
--- a/.github/workflows/sync-tarantool-schemas.yaml
+++ b/.github/workflows/sync-tarantool-schemas.yaml
@@ -75,9 +75,17 @@ jobs:
           branch: ${{ env.PR_BRANCH }}
           base: master
           add-paths: tarantool/schemas
-          commit-message: "tarantool: embed JSON Schemas for ${{ steps.schemasync.outputs.added }}"
+          commit-message: |
+            tarantool: embed new JSON Schemas
+
+            Automated sync of Tarantool JSON Schemas.
+
+            Added versions: ${{ steps.schemasync.outputs.added }}.
           committer: "${{ env.BOT_NAME }} <${{ env.BOT_EMAIL }}>"
           author: "${{ env.BOT_NAME }} <${{ env.BOT_EMAIL }}>"
-          title: "tarantool: embed JSON Schemas for ${{ steps.schemasync.outputs.added }}"
-          body: "Automated sync of Tarantool JSON Schemas. Added versions: ${{ steps.schemasync.outputs.added }}."
+          title: "tarantool: embed new JSON Schemas"
+          body: |
+            Automated sync of Tarantool JSON Schemas.
+
+            Added versions: ${{ steps.schemasync.outputs.added }}.
           delete-branch: true

--- a/internal/tools/schemasync/sync.go
+++ b/internal/tools/schemasync/sync.go
@@ -42,8 +42,8 @@ type Config struct {
 	Logger      *slog.Logger
 }
 
-// Run prints exactly one stdout line of the form "added=<csv>" as the
-// machine-readable handoff to the workflow step that opens the PR.
+// Run prints exactly one stdout line of the form "added=<v1>, <v2>, ..." as
+// the machine-readable handoff to the workflow step that opens the PR.
 func Run(ctx context.Context, cfg Config) error {
 	if cfg.HTTPClient == nil {
 		return errNilHTTPClient
@@ -104,7 +104,7 @@ func Run(ctx context.Context, cfg Config) error {
 		added = append(added, version)
 	}
 
-	_, err = fmt.Fprintf(os.Stdout, "added=%s\n", strings.Join(added, ","))
+	_, err = fmt.Fprintf(os.Stdout, "added=%s\n", strings.Join(added, ", "))
 	if err != nil {
 		return fmt.Errorf("write stdout: %w", err)
 	}


### PR DESCRIPTION
Before this change commit message was:

```
  tarantool: embed JSON Schemas for 3.2.1,3.2.0,3.1.2,3.1.1,3.1.0,3.0.2,3.0.1,3.0.0
```

So it was single write and produced unreadable result. Now it creates:

```
  tarantool: embed new JSON Schemas

  Automated sync of Tarantool JSON Schemas.

  Added versions: 3.2.1, 3.2.0, 3.1.2, 3.1.1, 3.1.0, 3.0.2, 3.0.1, 3.0.0.
```

Related to TNTP-7586