### PR TITLE
config: add MutableConfig.Snapshot for stable read views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   state on failure, and read methods (`Get`, `Lookup`, `Stat`, `Walk`, `Slice`,
   `Effective`, `EffectiveAll`) take a read lock. Modified keys get a bumped
   revision and `"modified"` source.
+* `MutableConfig.Snapshot()` returns a deep-copied read-only `Config` decoupled
+  from the live tree, so a long-lived reader can keep a stable view while other
+  goroutines continue mutating the configuration.
 
 ### Changed
 

--- a/config.go
+++ b/config.go
@@ -462,6 +462,16 @@ func (mc *MutableConfig) EffectiveAll() (map[string]Config, error) {
 	return mc.Config.EffectiveAll()
 }
 
+// Snapshot returns a deep copy of the current configuration as a read-only Config.
+// The returned value is decoupled from the live MutableConfig, so concurrent mutations
+// after Snapshot returns are not observed by the snapshot.
+func (mc *MutableConfig) Snapshot() Config {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	return newConfig(cloneNode(mc.root), mc.inheritances)
+}
+
 // Set sets or overwrites a value at the specified path.
 // The key's metadata is updated: Source becomes "modified", and Revision is incremented.
 // If validation fails, the tree is restored to its previous state.

--- a/config_test.go
+++ b/config_test.go
@@ -868,3 +868,55 @@ func TestMutableConfig_Effective_AfterMutation(t *testing.T) {
 		assert.False(t, ok, "Effective should not see a key removed via Delete")
 	})
 }
+
+func TestMutableConfig_Snapshot_Isolation(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"key": "original"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	snap := cfg.Snapshot()
+
+	// Mutate the live config after taking the snapshot.
+	require.NoError(t, cfg.Set(config.NewKeyPath("key"), "updated"))
+
+	// Snapshot keeps the original value.
+	var snapVal string
+
+	_, err := snap.Get(config.NewKeyPath("key"), &snapVal)
+	require.NoError(t, err)
+	assert.Equal(t, "original", snapVal)
+
+	// Live config sees the new value.
+	var liveVal string
+
+	_, err = cfg.Get(config.NewKeyPath("key"), &liveVal)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", liveVal)
+}
+
+func TestMutableConfig_Snapshot_KeyAddedAfterSnapshotInvisible(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"existing": "value"}
+	col := collectors.NewMap(data)
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(col)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	snap := cfg.Snapshot()
+
+	require.NoError(t, cfg.Set(config.NewKeyPath("added"), "later"))
+
+	_, ok := snap.Lookup(config.NewKeyPath("added"))
+	assert.False(t, ok, "snapshot should not observe keys added after Snapshot()")
+}


### PR DESCRIPTION
Add Snapshot method that returns a deep-copied Config so a long-lived reader can hold a stable view while another goroutine continues mutating the live configuration.

- Without it, the RWMutex protects only single calls, not the lifetime of values the caller keeps.
- The snapshot is decoupled from the live MutableConfig, so concurrent writes after Snapshot returns are not observed.

Part of TNTP-5724