### PR TITLE
config: add WithoutValidation to skip Build-time validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * `MutableConfig.Snapshot()` returns a deep-copied read-only `Config` decoupled
   from the live tree, so a long-lived reader can keep a stable view while other
   goroutines continue mutating the configuration.
+* `Builder.WithoutValidation()` skips the Build-time validation pass while
+  retaining the configured validator: `BuildMutable` still attaches it to the
+  resulting `MutableConfig` so runtime mutations remain validated.
+* `tarantool.Builder.WithoutValidation()` loads the schema for env-path
+  resolution but skips JSON-Schema validation at Build time, enabling
+  schema-aware env-var routing for intentionally-partial configs.
 
 ### Changed
 

--- a/builder.go
+++ b/builder.go
@@ -20,6 +20,9 @@ type Builder struct {
 	collectors []Collector
 	// Validator for validation of the final configuration.
 	validator validator.Validator
+	// skipValidation, when true, bypasses the Build-time Validate pass.
+	// The validator is still carried into MutableConfig.
+	skipValidation bool
 	// Inheritance hierarchies for configuration inheritance.
 	inheritances []inheritanceConfig
 	// Merger defines how values are merged into the configuration tree.
@@ -28,7 +31,13 @@ type Builder struct {
 
 // NewBuilder creates a new instance of Builder.
 func NewBuilder() Builder {
-	return Builder{collectors: nil, validator: nil, inheritances: nil, merger: nil}
+	return Builder{
+		collectors:     nil,
+		validator:      nil,
+		skipValidation: false,
+		inheritances:   nil,
+		merger:         nil,
+	}
 }
 
 // AddCollector adds a new data source to the build pipeline.
@@ -80,6 +89,19 @@ func (b *Builder) MustWithJSONSchema(schema io.Reader) Builder {
 	}
 
 	return result
+}
+
+// WithoutValidation skips the Build-time validation pass. Any validator
+// configured via [Builder.WithValidator] or [Builder.WithJSONSchema] is
+// retained: [Builder.BuildMutable] still attaches it to the resulting
+// [MutableConfig], so runtime mutations (Set/Merge/Update) remain validated.
+//
+// Useful when initial sources are intentionally partial (e.g. completed
+// later by env vars or a remote storage layer) but mutation-time
+// validation is still desired.
+func (b *Builder) WithoutValidation() Builder {
+	b.skipValidation = true
+	return *b
 }
 
 // WithMerger sets a custom merger for the configuration assembly.
@@ -184,7 +206,7 @@ func (b *Builder) Build(ctx context.Context) (Config, []error) {
 		return Config{root: nil, inheritances: nil}, errs
 	}
 
-	if b.validator != nil {
+	if b.validator != nil && !b.skipValidation {
 		validationErrs := b.validator.Validate(root)
 		for i := range validationErrs {
 			errs = append(errs, &validationErrs[i])

--- a/builder_validation_test.go
+++ b/builder_validation_test.go
@@ -210,3 +210,63 @@ func TestBuilder_BuildMutable_Validation(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "properties")
 }
+
+func TestBuilder_WithoutValidation_SkipsBuildTimeValidation(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockValidator{
+		errors: []validator.ValidationError{
+			{
+				Path:    config.NewKeyPath("port"),
+				Range:   validator.NewEmptyRange(),
+				Code:    "range",
+				Message: "port must be between 1024 and 65535",
+			},
+		},
+	}
+
+	builder := config.NewBuilder()
+
+	builder = builder.WithValidator(mock)
+	builder = builder.WithoutValidation()
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"port": 80,
+	}))
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs, "Build-time validation must be skipped")
+
+	var port int
+
+	_, err := cfg.Get(config.NewKeyPath("port"), &port)
+	require.NoError(t, err)
+	assert.Equal(t, 80, port)
+}
+
+func TestBuilder_WithoutValidation_MutableConfigStillValidates(t *testing.T) {
+	t.Parallel()
+
+	schema := `{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"properties": {
+			"port": { "type": "integer", "minimum": 1024 }
+		}
+	}`
+
+	builder := config.NewBuilder()
+
+	builder = builder.MustWithJSONSchema(strings.NewReader(schema))
+	builder = builder.WithoutValidation()
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"port": 80, // would normally fail validation.
+	}))
+
+	mcfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs, "Build-time validation must be skipped")
+
+	// The validator survives — runtime mutations are still validated.
+	err := mcfg.Set(config.NewKeyPath("port"), 100)
+	require.Error(t, err, "MutableConfig must keep validating runtime mutations")
+	assert.Contains(t, err.Error(), "properties")
+}

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -38,14 +38,15 @@ type Builder struct {
 	storage    *integrity.Typed[[]byte]
 	storageKey string
 
-	schema        []byte
-	schemaFile    string
-	schemaVersion string
-	schemaURL     string
-	schemaURLSet  bool
-	schemaHTTP    bool
-	skipSchema    bool
-	httpClient    *http.Client
+	schema         []byte
+	schemaFile     string
+	schemaVersion  string
+	schemaURL      string
+	schemaURLSet   bool
+	schemaHTTP     bool
+	skipSchema     bool
+	skipValidation bool
+	httpClient     *http.Client
 
 	inheritanceOpts []config.InheritanceOption
 
@@ -188,6 +189,18 @@ func (b *Builder) WithHTTPClient(client *http.Client) *Builder {
 // [ErrConflictingSchemaOptions] at [Builder.Build] time.
 func (b *Builder) WithoutSchema() *Builder {
 	b.skipSchema = true
+
+	return b
+}
+
+// WithoutValidation loads the schema for env-path resolution but skips
+// JSON-Schema validation at [Builder.Build] time. Independent of the
+// `With*Schema*` source selection — pair it with any of them to get
+// schema-aware env-var routing without enforcing the full schema on the
+// merged tree. Has no effect when combined with [Builder.WithoutSchema]
+// (no schema is loaded in that case).
+func (b *Builder) WithoutValidation() *Builder {
+	b.skipValidation = true
 
 	return b
 }
@@ -456,7 +469,7 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 	)
 
 	// 5. Schema validation.
-	if !b.skipSchema {
+	if !b.skipSchema && !b.skipValidation {
 		inner, err = inner.WithJSONSchema(bytes.NewReader(schemaBytes))
 		if err != nil {
 			return config.Builder{}, fmt.Errorf("json schema: %w", err)

--- a/tarantool/builder_envschema_test.go
+++ b/tarantool/builder_envschema_test.go
@@ -139,6 +139,63 @@ func TestBuild_Env_NoSchema_HeuristicUnchanged(t *testing.T) {
 		"without schema, naive split sends the value to the wrong path")
 }
 
+func TestBuild_WithoutValidation_KeepsSchemaAwareEnvRouting(t *testing.T) {
+	schema := []byte(`{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"properties": {
+			"audit_log": {
+				"type": "object",
+				"properties": {
+					"nonblock": { "type": "boolean" }
+				}
+			}
+		},
+		"additionalProperties": false
+	}`)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, cfgPath, "audit_log:\n  nonblock: not-a-bool\n")
+
+	t.Setenv("TT_AUDIT_LOG_NONBLOCK", "still-not-a-bool")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithSchema(schema).
+		WithoutValidation().
+		Build(ctx)
+	require.NoError(t, err, "validation must be skipped despite invalid types")
+
+	var nonblock string
+
+	_, err = cfg.Get(config.NewKeyPath("audit_log/nonblock"), &nonblock)
+	require.NoError(t, err)
+	assert.Equal(t, "still-not-a-bool", nonblock,
+		"env var must be routed via the schema trie, not the naive split")
+}
+
+func TestBuild_WithoutValidation_SchemaStillRequired(t *testing.T) {
+	t.Setenv("TT_AUDIT_LOG_NONBLOCK", "true")
+
+	ctx := context.Background()
+
+	cfg, err := tarantool.New().
+		WithSchemaFile(fixtureSchemaPath).
+		WithoutValidation().
+		Build(ctx)
+	require.NoError(t, err)
+
+	var nonblock string
+
+	_, err = cfg.Get(config.NewKeyPath("audit_log/nonblock"), &nonblock)
+	require.NoError(t, err)
+	assert.Equal(t, "true", nonblock,
+		"WithoutValidation alone keeps schema-aware env routing intact")
+}
+
 func TestBuild_Env_SchemaAware_Wildcard(t *testing.T) {
 	t.Setenv("TT_GROUPS_FOO_REPLICASETS_BAR_INSTANCES_BAZ_IPROTO_LISTEN", "3302")
 


### PR DESCRIPTION
Add a `WithoutValidation` toggle to both the root and the Tarantool builders so a schema can be loaded without enforcing it at Build time.

- Root `Builder.WithoutValidation` skips the Build-time `Validate` pass. The validator stays attached so `BuildMutable` still validates runtime mutations on `MutableConfig`.
- `tarantool.Builder.WithoutValidation` keeps schema-aware env-var routing (the schema trie is still built) but skips JSON-Schema validation of the merged tree, useful for intentionally partial bootstrap configs.

Part of TNTP-7660