### PR TITLE
tarantool: lazy-load embedded JSON schemas

### DIFF
--- a/internal/race/doc.go
+++ b/internal/race/doc.go
@@ -1,0 +1,6 @@
+// Package race exposes whether the binary was built with the race detector
+// enabled (-race). Callers use it to skip CPU-bound work under race
+// instrumentation where race coverage adds nothing — e.g. one-shot decode
+// sweeps that are slow enough to blow per-test timeouts when the race
+// runtime amplifies allocator and recursive-call costs.
+package race

--- a/internal/race/race_off.go
+++ b/internal/race/race_off.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package race
+
+// Enabled reports whether the binary was built with -race.
+func Enabled() bool { return false }

--- a/internal/race/race_on.go
+++ b/internal/race/race_on.go
@@ -1,0 +1,6 @@
+//go:build race
+
+package race
+
+// Enabled reports whether the binary was built with -race.
+func Enabled() bool { return true }

--- a/tarantool/errors.go
+++ b/tarantool/errors.go
@@ -13,6 +13,11 @@ var (
 	// ErrSchemaRead is returned when a local schema file cannot be read.
 	ErrSchemaRead = errors.New("tarantool: failed to read schema file")
 
+	// ErrSchemaLoad is returned when an embedded schema payload cannot be
+	// read from the embed FS or fails gzip decompression — a build-time
+	// corruption, surfaced rather than panicked.
+	ErrSchemaLoad = errors.New("tarantool: failed to load embedded schema")
+
 	// ErrInvalidSchema is returned when schema bytes fail JSON Schema compilation.
 	ErrInvalidSchema = errors.New("tarantool: invalid json schema")
 

--- a/tarantool/schema.go
+++ b/tarantool/schema.go
@@ -32,12 +32,7 @@ func (b *Builder) resolveSchema(ctx context.Context) ([]byte, error) {
 	}
 
 	if b.schemaVersion != "" {
-		schema, ok := Schema(b.schemaVersion)
-		if !ok {
-			return nil, fmt.Errorf("%w: %q", ErrUnknownSchemaVersion, b.schemaVersion)
-		}
-
-		return schema, nil
+		return Schema(b.schemaVersion)
 	}
 
 	if b.schemaURLSet {
@@ -49,9 +44,9 @@ func (b *Builder) resolveSchema(ctx context.Context) ([]byte, error) {
 	}
 
 	// Default: newest embedded version.
-	_, schema, ok := newestEmbeddedSchema()
-	if !ok {
-		return nil, fmt.Errorf("%w: no embedded schemas available", ErrUnknownSchemaVersion)
+	_, schema, err := newestEmbeddedSchema()
+	if err != nil {
+		return nil, err
 	}
 
 	return schema, nil

--- a/tarantool/schemas.go
+++ b/tarantool/schemas.go
@@ -15,10 +15,17 @@ import (
 //go:embed schemas/*/config.schema.json.gz
 var embeddedSchemas embed.FS
 
-// Sealed after init — read without a mutex on the assumption of no further writes.
+// Embedded versions are discovered (and sorted) once at init from the embed
+// directory listing. The gzipped payload for each version is decompressed
+// lazily on first access via [loadEmbedded] — keeping startup cheap and
+// avoiding ~2 MB of decompressed JSON in memory for callers that only ever
+// touch one version (or none).
 //
 //nolint:gochecknoglobals // sealed after init; treated as read-only.
-var embeddedRegistry = make(map[string][]byte)
+var (
+	embeddedVersions []string                          // sorted ascending by semver.
+	embeddedLoaders  map[string]func() ([]byte, error) // per-version sync.OnceValues.
+)
 
 //nolint:gochecknoglobals // package-level user registry is part of the public API.
 var (
@@ -26,12 +33,15 @@ var (
 	userRegistry   = make(map[string][]byte)
 )
 
-//nolint:gochecknoinits // auto-register embedded schemas at package load
+//nolint:gochecknoinits // discover embedded versions at package load
 func init() {
 	entries, err := embeddedSchemas.ReadDir("schemas")
 	if err != nil {
 		panic("tarantool: failed to read embedded schemas directory: " + err.Error())
 	}
+
+	embeddedLoaders = make(map[string]func() ([]byte, error), len(entries))
+	embeddedVersions = make([]string, 0, len(entries))
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -41,23 +51,59 @@ func init() {
 		version := entry.Name()
 		path := "schemas/" + version + "/config.schema.json.gz"
 
-		compressed, readErr := fs.ReadFile(embeddedSchemas, path)
-		if readErr != nil {
-			panic(fmt.Sprintf("tarantool: failed to read embedded schema for version %s: %s", version, readErr))
-		}
+		embeddedVersions = append(embeddedVersions, version)
+		embeddedLoaders[version] = sync.OnceValues(func() ([]byte, error) {
+			compressed, err := fs.ReadFile(embeddedSchemas, path)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s: %w", ErrSchemaLoad, version, err)
+			}
 
-		data, decompErr := gunzip(compressed)
-		if decompErr != nil {
-			panic(fmt.Sprintf("tarantool: failed to decompress embedded schema for version %s: %s", version, decompErr))
-		}
+			data, err := gunzip(compressed)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %s: %w", ErrSchemaLoad, version, err)
+			}
 
-		_, compErr := jsonschema.NewCompiler().Compile(data)
-		if compErr != nil {
-			panic(fmt.Sprintf("tarantool: embedded schema for version %s failed to compile: %s", version, compErr))
-		}
-
-		embeddedRegistry[version] = data
+			return data, nil
+		})
 	}
+
+	sortSemverAsc(embeddedVersions)
+}
+
+// sortSemverAsc sorts the slice in place ascending by [compareSemver] using
+// insertion sort — the embedded version list is small (<100), so we avoid
+// pulling in the sort package for a single call site.
+//
+//nolint:varnamelen // standard insertion-sort indices
+func sortSemverAsc(versions []string) {
+	for i := 1; i < len(versions); i++ {
+		key := versions[i]
+
+		j := i - 1
+		for j >= 0 && compareSemver(versions[j], key) > 0 {
+			versions[j+1] = versions[j]
+			j--
+		}
+
+		versions[j+1] = key
+	}
+}
+
+// loadEmbedded returns the (cached, lazily-decompressed) schema bytes for an
+// embedded version. The bool reports whether the version is in the embedded
+// registry; the error reports a load/decompression failure (wrapping
+// [ErrSchemaLoad]) for a known version. The returned slice is shared across
+// callers and must not be modified — callers handing it back to the public
+// API are responsible for taking a defensive copy.
+func loadEmbedded(version string) ([]byte, bool, error) {
+	loader, ok := embeddedLoaders[version]
+	if !ok {
+		return nil, false, nil
+	}
+
+	data, err := loader()
+
+	return data, true, err
 }
 
 // gunzip decompresses gzip-encoded bytes and returns the plaintext.
@@ -102,8 +148,11 @@ func RegisterSchema(version string, schema []byte) error {
 
 // Schema returns a defensive copy of the schema bytes registered for version.
 // User registrations take precedence over embedded versions with the same key.
-// Returns (nil, false) if the version is not known to either registry.
-func Schema(version string) ([]byte, bool) {
+//
+// Returns an error wrapping [ErrUnknownSchemaVersion] if the version is not
+// known to either registry, or [ErrSchemaLoad] if the embedded payload exists
+// but failed to read or decompress.
+func Schema(version string) ([]byte, error) {
 	userRegistryMu.RLock()
 
 	stored, ok := userRegistry[version]
@@ -111,16 +160,22 @@ func Schema(version string) ([]byte, bool) {
 	userRegistryMu.RUnlock()
 
 	if !ok {
-		stored, ok = embeddedRegistry[version]
+		var err error
+
+		stored, ok, err = loadEmbedded(version)
+		if err != nil {
+			return nil, err
+		}
+
 		if !ok {
-			return nil, false
+			return nil, fmt.Errorf("%w: %q", ErrUnknownSchemaVersion, version)
 		}
 	}
 
 	out := make([]byte, len(stored))
 	copy(out, stored)
 
-	return out, true
+	return out, nil
 }
 
 // SchemaVersions returns a slice of all version strings known to either the
@@ -129,10 +184,10 @@ func Schema(version string) ([]byte, bool) {
 func SchemaVersions() []string {
 	userRegistryMu.RLock()
 
-	versions := make([]string, 0, len(embeddedRegistry)+len(userRegistry))
-	seen := make(map[string]struct{}, len(embeddedRegistry)+len(userRegistry))
+	versions := make([]string, 0, len(embeddedVersions)+len(userRegistry))
+	seen := make(map[string]struct{}, len(embeddedVersions)+len(userRegistry))
 
-	for v := range embeddedRegistry {
+	for _, v := range embeddedVersions {
 		versions = append(versions, v)
 		seen[v] = struct{}{}
 	}
@@ -147,44 +202,31 @@ func SchemaVersions() []string {
 
 	userRegistryMu.RUnlock()
 
-	// Sort using semver comparator, not strings.Sort (lexicographic would
-	// misorder e.g. "3.10.0" before "3.5.0").
-	n := len(versions)
-	for i := 1; i < n; i++ {
-		key := versions[i]
-
-		j := i - 1 //nolint:varnamelen // standard insertion-sort index
-		for j >= 0 && compareSemver(versions[j], key) > 0 {
-			versions[j+1] = versions[j]
-			j--
-		}
-
-		versions[j+1] = key
-	}
+	sortSemverAsc(versions)
 
 	return versions
 }
 
 // User registrations are intentionally ignored: the default fallback must be
 // deterministic and unaffected by runtime [RegisterSchema] calls.
-func newestEmbeddedSchema() (string, []byte, bool) {
-	var bestVer string
-
-	var bestBytes []byte
-
-	for v, b := range embeddedRegistry {
-		if bestVer == "" || compareSemver(v, bestVer) > 0 {
-			bestVer = v
-			bestBytes = b
-		}
+//
+// Returns an error wrapping [ErrUnknownSchemaVersion] when no embedded
+// schemas are available, or [ErrSchemaLoad] when the newest payload fails to
+// load.
+func newestEmbeddedSchema() (string, []byte, error) {
+	if len(embeddedVersions) == 0 {
+		return "", nil, fmt.Errorf("%w: no embedded schemas available", ErrUnknownSchemaVersion)
 	}
 
-	if bestVer == "" {
-		return "", nil, false
+	bestVer := embeddedVersions[len(embeddedVersions)-1]
+
+	stored, _, err := loadEmbedded(bestVer)
+	if err != nil {
+		return "", nil, err
 	}
 
-	out := make([]byte, len(bestBytes))
-	copy(out, bestBytes)
+	out := make([]byte, len(stored))
+	copy(out, stored)
 
-	return bestVer, out, true
+	return bestVer, out, nil
 }

--- a/tarantool/schemas_internal_test.go
+++ b/tarantool/schemas_internal_test.go
@@ -3,15 +3,49 @@ package tarantool
 import (
 	"testing"
 
+	"github.com/kaptinlin/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config/internal/race"
 )
+
+// Replaces the eager init-time validation: ensures every shipped schema
+// decompresses cleanly and compiles as a valid JSON Schema. A broken embed
+// payload would otherwise only surface when a caller hits that exact version.
+//
+// Skipped under -race and -short: kaptinlin/jsonschema's deeply recursive
+// UnmarshalJSON over the largest shipped schema is ~minutes per compile under
+// race instrumentation, and `make testrace` runs `-count=100`, which would
+// blow the per-package timeout. The decompress+compile work has no
+// concurrency to exercise, so race coverage adds nothing here.
+func TestEmbeddedSchemas_AllDecompressAndCompile(t *testing.T) {
+	if testing.Short() || race.Enabled() {
+		t.Skip("skipping schema compile sweep under -short / -race")
+	}
+
+	t.Parallel()
+
+	require.NotEmpty(t, embeddedVersions, "must ship at least one embedded schema")
+
+	compiler := jsonschema.NewCompiler()
+
+	for _, version := range embeddedVersions {
+		data, ok, err := loadEmbedded(version)
+		require.NoErrorf(t, err, "loadEmbedded(%q) must not error", version)
+		require.Truef(t, ok, "loadEmbedded(%q) must find the version", version)
+		require.NotEmptyf(t, data, "embedded schema %q must be non-empty", version)
+
+		_, err = compiler.Compile(data)
+		require.NoErrorf(t, err, "embedded schema %q must compile", version)
+	}
+}
 
 func TestNewestEmbeddedSchema_IgnoresUserRegistry(t *testing.T) {
 	t.Parallel()
 
-	want, embeddedBytes, ok := newestEmbeddedSchema()
-	require.True(t, ok, "must ship at least one embedded schema")
+	want, embeddedBytes, err := newestEmbeddedSchema()
+	require.NoError(t, err, "must ship at least one embedded schema")
 	require.NotEmpty(t, embeddedBytes)
 
 	// "zzz" is non-parseable — compareSemver sorts it after any numeric
@@ -19,8 +53,8 @@ func TestNewestEmbeddedSchema_IgnoresUserRegistry(t *testing.T) {
 	require.NoError(t, RegisterSchema("99.99.0", []byte(`{"type":"object"}`)))
 	require.NoError(t, RegisterSchema("zzz", []byte(`{"type":"object"}`)))
 
-	got, _, ok := newestEmbeddedSchema()
-	require.True(t, ok)
+	got, _, err := newestEmbeddedSchema()
+	require.NoError(t, err)
 	assert.Equal(t, want, got,
 		"newestEmbeddedSchema must only consider embedded versions")
 }

--- a/tarantool/schemas_test.go
+++ b/tarantool/schemas_test.go
@@ -27,8 +27,8 @@ func TestRegisterSchema_ValidSchema(t *testing.T) {
 	err := tarantool.RegisterSchema(ver, minimalValidSchema)
 	require.NoError(t, err)
 
-	got, ok := tarantool.Schema(ver)
-	require.True(t, ok)
+	got, err := tarantool.Schema(ver)
+	require.NoError(t, err)
 	assert.Equal(t, minimalValidSchema, got)
 }
 
@@ -42,13 +42,13 @@ func TestRegisterSchema_DefensiveCopy(t *testing.T) {
 	err := tarantool.RegisterSchema(ver, input)
 	require.NoError(t, err)
 
-	got1, ok := tarantool.Schema(ver)
-	require.True(t, ok)
+	got1, err := tarantool.Schema(ver)
+	require.NoError(t, err)
 
 	got1[0] = 'X'
 
-	got2, ok := tarantool.Schema(ver)
-	require.True(t, ok)
+	got2, err := tarantool.Schema(ver)
+	require.NoError(t, err)
 	assert.JSONEq(t, `{"type":"object"}`, string(got2), "stored bytes must not be affected by mutating a returned copy")
 }
 
@@ -66,8 +66,8 @@ func TestRegisterSchema_InputDefensiveCopy(t *testing.T) {
 
 	input[0] = 'Z'
 
-	got, ok := tarantool.Schema(ver)
-	require.True(t, ok)
+	got, err := tarantool.Schema(ver)
+	require.NoError(t, err)
 	assert.Equal(t, original, got, "stored bytes must not be affected by mutating the input slice after registration")
 }
 
@@ -80,8 +80,9 @@ func TestRegisterSchema_InvalidJSON(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIsf(t, err, tarantool.ErrInvalidSchema, "error must wrap ErrInvalidSchema, got: %v", err)
 
-	_, ok := tarantool.Schema(ver)
-	assert.False(t, ok, "Schema() must return (nil, false) after a failed registration")
+	_, err = tarantool.Schema(ver)
+	assert.ErrorIs(t, err, tarantool.ErrUnknownSchemaVersion,
+		"Schema() must report unknown version after a failed registration")
 }
 
 func TestRegisterSchema_InvalidSchema(t *testing.T) {
@@ -93,8 +94,9 @@ func TestRegisterSchema_InvalidSchema(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIsf(t, err, tarantool.ErrInvalidSchema, "error must wrap ErrInvalidSchema, got: %v", err)
 
-	_, ok := tarantool.Schema(ver)
-	assert.False(t, ok, "Schema() must return (nil, false) after a failed registration")
+	_, err = tarantool.Schema(ver)
+	assert.ErrorIs(t, err, tarantool.ErrUnknownSchemaVersion,
+		"Schema() must report unknown version after a failed registration")
 }
 
 func TestRegisterSchema_OverwriteVersion(t *testing.T) {
@@ -111,8 +113,8 @@ func TestRegisterSchema_OverwriteVersion(t *testing.T) {
 	err = tarantool.RegisterSchema(ver, second)
 	require.NoError(t, err)
 
-	got, ok := tarantool.Schema(ver)
-	require.True(t, ok)
+	got, err := tarantool.Schema(ver)
+	require.NoError(t, err)
 	assert.Equal(t, second, got, "second registration must overwrite the first")
 }
 


### PR DESCRIPTION
Decompressing and compiling all 22 shipped JSON Schemas at package init cost ~22 MiB of heap and noticeable startup time, even for callers that only ever touch one version (or none). The embed directory is now walked at init to discover versions, and per-version `sync.OnceValues` closures defer gzip read and JSON Schema compile to first access; an internal test decompresses and compiles every shipped schema so a corrupted embed payload still fails the build.

Post-import `HeapAlloc` drops from ~22 MiB to ~0.4 MiB on programs that only import the package without resolving a schema.