### PR TITLE
jsonschema: substitute params in error messages

### DIFF
--- a/validators/jsonschema/errors.go
+++ b/validators/jsonschema/errors.go
@@ -82,19 +82,23 @@ func (ve *validationErrors) addErrors(result *jsonschema.EvaluationResult, baseP
 
 // formatErrorMessage creates a user-friendly error message.
 func formatErrorMessage(err *jsonschema.EvaluationError) string {
+	// err.Message is a raw template with {property}/{received}/{expected} placeholders;
+	// only (*EvaluationError).Error() substitutes them from err.Params.
+	body := err.Error()
+
 	// Format based on keyword type for better readability.
 	switch err.Keyword {
 	case "required":
-		return "missing required property: " + err.Message
+		return "missing required property: " + body
 	case "type":
-		return "invalid type: " + err.Message
+		return "invalid type: " + body
 	case "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum":
-		return "value out of range: " + err.Message
+		return "value out of range: " + body
 	case "pattern":
-		return "value does not match pattern: " + err.Message
+		return "value does not match pattern: " + body
 	case "enum":
-		return "value not in allowed set: " + err.Message
+		return "value not in allowed set: " + body
 	default:
-		return err.Message
+		return body
 	}
 }

--- a/validators/jsonschema/errors_test.go
+++ b/validators/jsonschema/errors_test.go
@@ -194,6 +194,63 @@ func TestFormatErrorMessage_Enum(t *testing.T) {
 	assert.Equal(t, "value not in allowed set: must be one of [red, green, blue]", msg)
 }
 
+func TestFormatErrorMessage_SubstitutesParams(t *testing.T) {
+	t.Parallel()
+
+	// Real EvaluationError values carry a template Message plus Params; the
+	// substituted text only appears via Error(). Verify formatErrorMessage no
+	// longer leaks raw {placeholders} for the keywords that trigger this in
+	// practice.
+	tests := []struct {
+		name string
+		err  *jsonschema.EvaluationError
+		want string
+	}{
+		{
+			name: "enum",
+			err: &jsonschema.EvaluationError{
+				Keyword: "enum",
+				Message: "Value {received} should be one of the allowed values: {expected}",
+				Params: map[string]any{
+					"received": "rs",
+					"expected": "[ro, rw]",
+				},
+			},
+			want: "value not in allowed set: Value rs should be one of the allowed values: [ro, rw]",
+		},
+		{
+			name: "type",
+			err: &jsonschema.EvaluationError{
+				Keyword: "type",
+				Message: "Value is {received} but should be {expected}",
+				Params: map[string]any{
+					"received": "string",
+					"expected": "number",
+				},
+			},
+			want: "invalid type: Value is string but should be number",
+		},
+		{
+			name: "default",
+			err: &jsonschema.EvaluationError{
+				Keyword: "properties",
+				Message: "Properties {properties} do not match their schemas",
+				Params: map[string]any{
+					"properties": "[mode]",
+				},
+			},
+			want: "Properties [mode] do not match their schemas",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatErrorMessage(tt.err))
+		})
+	}
+}
+
 func TestFormatErrorMessage_Default(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`formatErrorMessage` concatenated `err.Message` directly, which is the raw template carrying `{received}`/`{expected}`/`{properties}` placeholders. The upstream substitution only runs in `(*EvaluationError).Error()`, so users saw literal `{placeholders}` in enum/type/properties error messages — for example `Value {received} should be one of the allowed values: {expected}` instead of `Value rs should be one of the allowed values: [ro, rw]`.

Switch to `err.Error()` so kaptinlin's `replace()` runs against `err.Params` before we wrap the message. Added a table-driven test that pins enum, type, and the default branch with real `Params` so the regression can't come back.