### PR TITLE
tarantool: align source precedence with documentation

### DIFF
--- a/integration/tarantool_integration_test.go
+++ b/integration/tarantool_integration_test.go
@@ -137,14 +137,19 @@ groups:
                   roles: ['admin']
 `
 
-// storageOverrideYAML is put into etcd to override specific keys
-// from the file-based config.
+// storageOverrideYAML is put into etcd. Per documented precedence,
+// the local YAML file wins on overlapping keys, so this YAML primarily
+// fills keys absent from the file-based config (memtx.memory) while
+// still defining a few overlapping keys to assert that the file wins.
 const storageOverrideYAML = `
 log:
   level: warn
 
 replication:
   connect_timeout: 30
+
+memtx:
+  memory: 268435456
 `
 
 func writeTestFile(t *testing.T, path, content string) {
@@ -162,7 +167,7 @@ func writeTestFile(t *testing.T, path, content string) {
 //   - Inheritance resolution (Effective / EffectiveAll)
 //   - No schema validation (WithoutSchema) to test without network dependency
 //
-// Priority: default-env < file < storage < env.
+// Priority: default-env < storage < file < env.
 func TestTarantool_Integration_FullStack(t *testing.T) {
 	cluster := testutil.NewEtcdTestCluster(t)
 	ctx := context.Background()
@@ -203,26 +208,33 @@ func TestTarantool_Integration_FullStack(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "election", failover, "file value should be present")
 
-	// 5b. Storage overrides file: log.level.
+	// 5b. File overrides storage: log.level.
 	var logLevel string
 
 	_, err = cfg.Get(config.NewKeyPath("log/level"), &logLevel)
 	require.NoError(t, err)
-	assert.Equal(t, "warn", logLevel, "storage should override file for log.level")
+	assert.Equal(t, "info", logLevel, "file should override storage for log.level")
 
-	// 5c. Storage overrides file: replication.connect_timeout.
+	// 5c. File overrides storage: replication.connect_timeout.
 	var connectTimeout int64
 
 	_, err = cfg.Get(config.NewKeyPath("replication/connect_timeout"), &connectTimeout)
 	require.NoError(t, err)
-	assert.Equal(t, int64(30), connectTimeout, "storage should override file for connect_timeout")
+	assert.Equal(t, int64(10), connectTimeout, "file should override storage for connect_timeout")
+
+	// 5c'. Storage fills key absent from file: memtx.memory.
+	var memtxMemory int64
+
+	_, err = cfg.Get(config.NewKeyPath("memtx/memory"), &memtxMemory)
+	require.NoError(t, err)
+	assert.Equal(t, int64(268435456), memtxMemory, "storage should fill key absent from file")
 
 	// 5d. Regular env overrides everything: replication.timeout.
 	var timeout string
 
 	_, err = cfg.Get(config.NewKeyPath("replication/timeout"), &timeout)
 	require.NoError(t, err)
-	assert.Equal(t, "99", timeout, "env should override storage+file for timeout")
+	assert.Equal(t, "99", timeout, "env should override file+storage for timeout")
 
 	// 5e. Default env fills missing key.
 	var ioCollect string
@@ -592,12 +604,12 @@ groups:
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	// Storage overrides file: log.level = debug.
+	// File overrides storage: log.level = info.
 	var logLevel string
 
 	_, err = cfg.Get(config.NewKeyPath("log/level"), &logLevel)
 	require.NoError(t, err)
-	assert.Equal(t, "debug", logLevel, "storage should override file")
+	assert.Equal(t, "info", logLevel, "file should override storage")
 
 	// Mutate at runtime.
 	err = cfg.Set(config.NewKeyPath("log/level"), "error")
@@ -659,12 +671,12 @@ groups:
 		Build(ctx)
 	require.NoError(t, err)
 
-	// Storage overrides dir: log.level.
+	// Config dir overrides storage: log.level.
 	var logLevel string
 
 	_, err = cfg.Get(config.NewKeyPath("log/level"), &logLevel)
 	require.NoError(t, err)
-	assert.Equal(t, "error", logLevel, "storage should override config dir")
+	assert.Equal(t, "info", logLevel, "config dir should override storage")
 
 	// Dir value present for non-overridden key.
 	var adminPw string

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -425,13 +425,20 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 
 	inner := config.NewBuilder()
 
-	// 1. Default env vars (lowest priority).
-	inner = inner.AddCollector(
+	// Sources in precedence order (highest to lowest), per docs:
+	//   1. TT_* environment variables.
+	//   2. Config file or directory.
+	//   3. Centralized storage.
+	//   4. TT_*_DEFAULT environment variables.
+	var sources []config.Collector
+
+	// 1. TT_* env vars (highest priority).
+	sources = append(sources,
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(envFilter(b.envPrefix, b.envIgnore, defaultEnvTransform(resolver))).
-			WithName("env-default").
-			WithSourceType(config.EnvDefaultSource),
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, regularEnvTransform(resolver))).
+			WithName("env").
+			WithSourceType(config.EnvSource),
 	)
 
 	// 2. Config file or directory.
@@ -445,28 +452,33 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 			return config.Builder{}, fmt.Errorf("config file: %w", sourceErr)
 		}
 
-		inner = inner.AddCollector(source)
+		sources = append(sources, source)
 	} else if b.configDir != "" {
-		inner = inner.AddCollector(
+		sources = append(sources,
 			collectors.NewDirectory(b.configDir, ".yaml", collectors.NewYamlFormat()),
 		)
 	}
 
 	// 3. Centralized storage.
 	if b.storage != nil {
-		inner = inner.AddCollector(
+		sources = append(sources,
 			collectors.NewStorage(b.storage, b.storageKey, collectors.NewYamlFormat()),
 		)
 	}
 
-	// 4. Env vars (highest priority).
-	inner = inner.AddCollector(
+	// 4. TT_*_DEFAULT env vars (lowest priority).
+	sources = append(sources,
 		collectors.NewEnv().
 			WithPrefix(b.envPrefix).
-			WithTransform(envFilter(b.envPrefix, b.envIgnore, regularEnvTransform(resolver))).
-			WithName("env").
-			WithSourceType(config.EnvSource),
+			WithTransform(envFilter(b.envPrefix, b.envIgnore, defaultEnvTransform(resolver))).
+			WithName("env-default").
+			WithSourceType(config.EnvDefaultSource),
 	)
+
+	// AddCollector treats later additions as higher priority, so add in reverse.
+	for i := len(sources) - 1; i >= 0; i-- {
+		inner = inner.AddCollector(sources[i])
+	}
 
 	// 5. Schema validation.
 	if !b.skipSchema && !b.skipValidation {

--- a/tarantool/builder_test.go
+++ b/tarantool/builder_test.go
@@ -148,7 +148,7 @@ func TestBuild_DefaultEnvLowestPriority(t *testing.T) {
 	assert.Equal(t, "default-host", host, "default env should fill missing keys")
 }
 
-func TestBuild_StorageOverridesFile(t *testing.T) {
+func TestBuild_FileOverridesStorage(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -157,7 +157,7 @@ func TestBuild_StorageOverridesFile(t *testing.T) {
 
 	mock := testutil.NewMockStorage()
 	testutil.PutIntegrity(mock, "/config/", "app",
-		[]byte("server:\n  host: storage-host\n"))
+		[]byte("server:\n  host: storage-host\n  region: storage-region\n"))
 
 	typed := testutil.NewRawTyped(mock, "/config/")
 	ctx := context.Background()
@@ -173,13 +173,13 @@ func TestBuild_StorageOverridesFile(t *testing.T) {
 
 	_, err = cfg.Get(config.NewKeyPath("server/host"), &host)
 	require.NoError(t, err)
-	assert.Equal(t, "storage-host", host, "storage should override file")
+	assert.Equal(t, "file-host", host, "file should override storage")
 
-	var port string
+	var region string
 
-	_, err = cfg.Get(config.NewKeyPath("server/port"), &port)
+	_, err = cfg.Get(config.NewKeyPath("server/region"), &region)
 	require.NoError(t, err)
-	assert.Equal(t, "8080", port, "file value should remain for non-overridden keys")
+	assert.Equal(t, "storage-region", region, "storage value should remain for non-overridden keys")
 }
 
 func TestBuild_EnvOverridesStorage(t *testing.T) {


### PR DESCRIPTION
The Tarantool builder docs state precedence (highest → lowest) as TT_* env vars, local YAML file, centralized storage, TT_*_DEFAULT env vars, but `buildInner` was adding the storage collector after the file collector — and since `AddCollector` is last-wins, that gave centralized storage higher priority than the local file, silently overriding file values from storage.

Reorganize `buildInner` so sources are listed top-down in the documented precedence order (env > file/dir > storage > env-default) and appended to the inner builder in reverse. Behavior now matches the docs: the local YAML file overrides centralized storage, with storage filling in keys absent from the file.

The previous `TestBuild_StorageOverridesFile` was asserting the doc-mismatching behavior; renamed to `TestBuild_FileOverridesStorage` and flipped its assertions.