### PR TITLE
config: use typed ModifiedSource name constant

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/meta"
 	"github.com/tarantool/go-config/tree"
 	"github.com/tarantool/go-config/validator"
 )
@@ -407,7 +408,6 @@ func (c *Config) collectLeafEntities(
 }
 
 // MutableConfig is an extension of Config that allows safe runtime modifications.
-// Note: MutableConfig is not implemented yet and is under active development.
 //
 // The validator (if any) lives on the embedded [Config]. Set/Merge/Update use
 // it to validate every mutation; [MutableConfig.Validate] re-runs it on the
@@ -435,7 +435,7 @@ func markModified(node *tree.Node) {
 		return
 	}
 
-	node.Source = "modified"
+	node.Source = meta.ModifiedSourceName
 	node.Revision = nextRevision(node.Revision)
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -6,16 +6,16 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/tarantool/go-config/meta"
 	"github.com/tarantool/go-config/tree"
 	"go.yaml.in/yaml/v3"
 )
 
 const (
-	yamlIndent      = 2
-	yamlFloatTag    = "!!float"
-	yamlNullTag     = "!!null"
-	yamlStringTag   = "!!str"
-	modifiedSrcName = "modified"
+	yamlIndent    = 2
+	yamlFloatTag  = "!!float"
+	yamlNullTag   = "!!null"
+	yamlStringTag = "!!str"
 )
 
 // YAMLAnnotation captures the YAML-specific information needed to faithfully
@@ -110,7 +110,7 @@ func nodeToYAML(node *tree.Node) (*yaml.Node, error) {
 // from the original annotation when the value has not been modified.
 func scalarNodeToYAML(node *tree.Node) (*yaml.Node, error) {
 	annotation := yamlAnnotation(node)
-	mutated := node.Source == modifiedSrcName
+	mutated := node.Source == meta.ModifiedSourceName
 
 	if annotation.Val != nil && !mutated {
 		clone := cloneScalarYAMLNode(annotation.Val)

--- a/meta/sourcetype.go
+++ b/meta/sourcetype.go
@@ -15,6 +15,9 @@ const (
 	// EnvSource indicates environment variables.
 	EnvSource
 	// ModifiedSource indicates dynamically modified data (e.g., at runtime) for MutableConfig.
-	// Note: ModifiedSource is not implemented yet and is under active development.
 	ModifiedSource
 )
+
+// ModifiedSourceName is the canonical Source name set on tree nodes mutated at
+// runtime via MutableConfig. It is the wire-level counterpart of [ModifiedSource].
+const ModifiedSourceName = "modified"

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -237,7 +237,6 @@ func (b *Builder) Build(ctx context.Context) (config.Config, error) {
 
 // BuildMutable is like [Builder.Build] but returns a [config.MutableConfig]
 // that allows runtime modifications.
-// Note: this method is not implemented yet and is under active development.
 func (b *Builder) BuildMutable(ctx context.Context) (*config.MutableConfig, error) {
 	inner, err := b.buildInner(ctx)
 	if err != nil {

--- a/validator/position.go
+++ b/validator/position.go
@@ -1,7 +1,6 @@
 package validator
 
 // Position describes a position in source file (for LSP integration).
-// Currently placeholder - will be populated when position tracking is implemented.
 type Position struct {
 	Line   int // Line number (1-based), 0 if unknown.
 	Column int // Column number (1-based), 0 if unknown.

--- a/value.go
+++ b/value.go
@@ -20,7 +20,6 @@ const (
 	// EnvSource indicates environment variables.
 	EnvSource = meta.EnvSource
 	// ModifiedSource indicates dynamically modified data (e.g., at runtime) for MutableConfig.
-	// Note: ModifiedSource is not implemented yet and is under active development.
 	ModifiedSource = meta.ModifiedSource
 )
 


### PR DESCRIPTION
Replace hard-coded `"modified"` string literals on the mutation and marshal path with a single canonical declaration in the `meta` package. `meta.ModifiedSourceName` lives alongside `meta.ModifiedSource`, so the typed enum and its wire-level name share one source of truth — `markModified` and the YAML marshaler now reference the constant instead of an untyped string.

While there, drops stale "not implemented yet / under active development" doc comments on `ModifiedSource`, `MutableConfig`, `Builder.BuildMutable` (tarantool), and `validator.Position`. All four are wired up and exercised in tests.

Closes #44