### PR TITLE
collectors: add Struct collector and StructToMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+* `collectors.Struct` collector reads configuration directly from a Go
+  struct via reflection, honoring `config` struct tags (falling back to
+  `yaml`), the `-` skip directive, and the `omitempty` and `inline`
+  options. The helper `collectors.StructToMap` exposes the same struct →
+  `map[string]any` conversion for standalone use.
+
 ### Changed
 
 ### Fixed

--- a/collectors/doc.go
+++ b/collectors/doc.go
@@ -4,6 +4,8 @@
 // # Collector Types
 //
 //   - [Map] — reads configuration from an in-memory map[string]any.
+//   - [Struct] — reads configuration from a Go struct via reflection, using
+//     `config`/`yaml` tags; see also [StructToMap].
 //   - [Env] — reads configuration from environment variables, with
 //     configurable prefix, delimiter, and key transformation.
 //   - [Storage] — reads multiple configuration documents from a key-value

--- a/collectors/errors.go
+++ b/collectors/errors.go
@@ -26,6 +26,9 @@ var (
 	ErrStorageValidation = errors.New("storage integrity validation failed")
 	// ErrDirectoryRead indicates that reading a directory failed.
 	ErrDirectoryRead = errors.New("directory read failed")
+	// ErrNotStruct indicates that a value expected to be a struct (or a
+	// pointer to one) was something else.
+	ErrNotStruct = errors.New("value is not a struct")
 )
 
 // FormatParseError indicates that parsing a configuration value with the

--- a/collectors/struct.go
+++ b/collectors/struct.go
@@ -1,0 +1,300 @@
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/tree"
+)
+
+// Struct reads configuration data from a Go struct using reflection.
+//
+// Field names come from the `config` struct tag, falling back to `yaml`, then
+// the lowercased field name. "-" skips a field, "omitempty" skips zero values,
+// and "inline" merges a struct/map field's keys into the enclosing map (an
+// anonymous field without "inline" is nested under its lowercased type name).
+// Unexported fields are ignored, except those promoted from an embedded struct.
+//
+// The struct is converted via [StructToMap] and flattened like the [Map]
+// collector: nested structs become nested maps, slices and arrays become
+// []any, []byte stays a byte slice, and maps are copied with keys stringified.
+//
+// Key order is preserved by default, like [YamlFormat]. If the value passed to
+// [NewStruct] is not a struct (nor a pointer to one), Read yields no values.
+type Struct struct {
+	data       any
+	name       string
+	sourceType config.SourceType
+	revision   config.RevisionType
+	keepOrder  bool
+}
+
+// NewStruct creates a Struct collector for the given value, which must be a
+// struct or a pointer to a struct. The source type defaults to
+// config.UnknownSource and key order is preserved by default.
+func NewStruct(data any) *Struct {
+	return &Struct{
+		data:       data,
+		name:       "struct",
+		sourceType: config.UnknownSource,
+		revision:   "",
+		keepOrder:  true,
+	}
+}
+
+// WithName sets a custom name for the collector.
+func (sc *Struct) WithName(name string) *Struct {
+	sc.name = name
+	return sc
+}
+
+// WithSourceType sets the source type for the collector.
+func (sc *Struct) WithSourceType(source config.SourceType) *Struct {
+	sc.sourceType = source
+	return sc
+}
+
+// WithRevision sets the revision for the collector.
+func (sc *Struct) WithRevision(rev config.RevisionType) *Struct {
+	sc.revision = rev
+	return sc
+}
+
+// WithKeepOrder sets whether the collector preserves key order.
+func (sc *Struct) WithKeepOrder(keep bool) *Struct {
+	sc.keepOrder = keep
+	return sc
+}
+
+// Read implements the Collector interface.
+func (sc *Struct) Read(ctx context.Context) <-chan config.Value {
+	valueCh := make(chan config.Value)
+
+	go func() {
+		defer close(valueCh)
+
+		data, err := StructToMap(sc.data)
+		if err != nil {
+			return
+		}
+
+		root := tree.New()
+		flattenMapIntoTree(root, config.NewKeyPath(""), data, sc.keepOrder)
+		walkTree(ctx, root, config.NewKeyPath(""), valueCh)
+	}()
+
+	return valueCh
+}
+
+// Name implements the Collector interface.
+func (sc *Struct) Name() string {
+	return sc.name
+}
+
+// Source implements the Collector interface.
+func (sc *Struct) Source() config.SourceType {
+	return sc.sourceType
+}
+
+// Revision implements the Collector interface.
+func (sc *Struct) Revision() config.RevisionType {
+	return sc.revision
+}
+
+// KeepOrder implements the Collector interface.
+func (sc *Struct) KeepOrder() bool {
+	return sc.keepOrder
+}
+
+// StructToMap converts a struct (or a pointer to one) into a map[string]any
+// using the same field-naming, tag, and value-conversion rules as the
+// [Struct] collector. It returns ErrNotStruct for any other input.
+func StructToMap(v any) (map[string]any, error) {
+	rval := derefValue(reflect.ValueOf(v))
+	if !rval.IsValid() || rval.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%w: got %T", ErrNotStruct, v)
+	}
+
+	out := map[string]any{}
+	structFieldsIntoMap(out, rval)
+
+	return out, nil
+}
+
+// derefValue unwraps pointers and interfaces, yielding the zero Value on a nil.
+func derefValue(rval reflect.Value) reflect.Value {
+	for rval.IsValid() && (rval.Kind() == reflect.Pointer || rval.Kind() == reflect.Interface) {
+		if rval.IsNil() {
+			return reflect.Value{}
+		}
+
+		rval = rval.Elem()
+	}
+
+	return rval
+}
+
+// structFieldsIntoMap writes the struct's fields into out per the tag rules
+// described on [StructToMap].
+func structFieldsIntoMap(out map[string]any, rval reflect.Value) {
+	rtype := rval.Type()
+
+	for idx := range rtype.NumField() {
+		sfield := rtype.Field(idx)
+		// Skip unexported fields, but keep embedded ones: their promoted
+		// exported fields are still reachable via reflection.
+		if !sfield.IsExported() && !sfield.Anonymous {
+			continue
+		}
+
+		name, opts := fieldTag(sfield)
+		if name == "-" {
+			continue
+		}
+
+		field := rval.Field(idx)
+		if opts.has("omitempty") && field.IsZero() {
+			continue
+		}
+
+		if opts.has("inline") && mergeInline(out, field) {
+			continue
+		}
+
+		key := name
+		if key == "" {
+			key = strings.ToLower(sfield.Name)
+		}
+
+		out[key] = goValue(field)
+	}
+}
+
+// mergeInline merges a struct- or map-valued field's keys into out, reporting
+// whether it did. A non-struct/non-map field is left to normal handling
+// (returns false); a nil one counts as an empty merge.
+func mergeInline(out map[string]any, field reflect.Value) bool {
+	deref := derefValue(field)
+	if !deref.IsValid() {
+		return true
+	}
+
+	switch {
+	case deref.Kind() == reflect.Struct:
+		structFieldsIntoMap(out, deref)
+		return true
+	case deref.Kind() == reflect.Map:
+		maps.Copy(out, mapToAny(deref))
+		return true
+	default:
+		return false
+	}
+}
+
+// goValue converts a reflect.Value into a plain Go value: structs and maps
+// become map[string]any (map keys stringified), slices/arrays become []any
+// (except []byte, kept as-is), anything unreadable or nil becomes nil, and
+// the rest is returned via Interface().
+func goValue(rval reflect.Value) any {
+	rval = derefValue(rval)
+	if !rval.IsValid() {
+		return nil
+	}
+
+	kind := rval.Kind()
+
+	switch {
+	case kind == reflect.Struct:
+		out := map[string]any{}
+		structFieldsIntoMap(out, rval)
+
+		return out
+	case kind == reflect.Map:
+		return mapToAny(rval)
+	case kind == reflect.Slice && rval.IsNil():
+		return nil
+	case kind == reflect.Slice && rval.Type().Elem().Kind() == reflect.Uint8:
+		return rval.Bytes()
+	case kind == reflect.Slice || kind == reflect.Array:
+		return sliceToAny(rval)
+	case !rval.CanInterface():
+		// Reachable only for an unexported, embedded scalar field.
+		return nil
+	default:
+		return rval.Interface()
+	}
+}
+
+// sliceToAny converts each element of a slice or array value into a []any.
+func sliceToAny(rval reflect.Value) []any {
+	out := make([]any, rval.Len())
+
+	for idx := range rval.Len() {
+		out[idx] = goValue(rval.Index(idx))
+	}
+
+	return out
+}
+
+// mapToAny copies a map value into a map[string]any, stringifying keys that
+// are not already strings via fmt.Sprint. A nil map yields a nil result.
+func mapToAny(rval reflect.Value) map[string]any {
+	if rval.IsNil() {
+		return nil
+	}
+
+	out := make(map[string]any, rval.Len())
+
+	iter := rval.MapRange()
+	for iter.Next() {
+		out[mapKeyString(iter.Key())] = goValue(iter.Value())
+	}
+
+	return out
+}
+
+// mapKeyString renders a map key as a string: string keys pass through, other
+// keys go through fmt.Sprint, and an invalid (nil interface) key becomes
+// "<nil>".
+func mapKeyString(key reflect.Value) string {
+	if key.Kind() == reflect.String {
+		return key.String()
+	}
+
+	if deref := derefValue(key); deref.IsValid() {
+		return fmt.Sprint(deref.Interface())
+	}
+
+	return "<nil>"
+}
+
+// tagOptions holds the comma-separated options of a struct tag (everything
+// after the name).
+type tagOptions []string
+
+func (o tagOptions) has(opt string) bool {
+	return slices.Contains(o, opt)
+}
+
+// fieldTag returns the configured name and options for a struct field,
+// preferring the `config` tag over the `yaml` tag. An absent tag yields an
+// empty name and no options.
+func fieldTag(sfield reflect.StructField) (string, tagOptions) {
+	raw, ok := sfield.Tag.Lookup("config")
+	if !ok {
+		raw, ok = sfield.Tag.Lookup("yaml")
+	}
+
+	if !ok {
+		return "", nil
+	}
+
+	parts := strings.Split(raw, ",")
+
+	return parts[0], tagOptions(parts[1:])
+}

--- a/collectors/struct_test.go
+++ b/collectors/struct_test.go
@@ -1,0 +1,217 @@
+package collectors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/internal/testutil"
+)
+
+type structLog struct {
+	Level string `config:"level"`
+	File  string `yaml:"file"`
+}
+
+type structServer struct {
+	Port    int      `config:"port"`
+	Hosts   []string `config:"hosts"`
+	Skipped string   `config:"-"`
+	private string   //nolint:unused
+}
+
+type structConfig struct {
+	Listen string               `config:"listen"`
+	Log    structLog            `config:"log"`
+	Server structServer         `config:"server"`
+	Extra  map[string]any       `config:"extra"`
+	Empty  string               `config:"empty,omitempty"`
+	Tags   map[int]string       `config:"tags"`
+	Nested map[string]structLog `config:"nested"`
+}
+
+func TestNewStruct(t *testing.T) {
+	t.Parallel()
+
+	coll := collectors.NewStruct(structConfig{})
+	require.NotNil(t, coll)
+	assert.Equal(t, "struct", coll.Name())
+	assert.Equal(t, config.UnknownSource, coll.Source())
+	assert.Equal(t, config.RevisionType(""), coll.Revision())
+	assert.True(t, coll.KeepOrder())
+}
+
+func TestStruct_Builders(t *testing.T) {
+	t.Parallel()
+
+	coll := collectors.NewStruct(structConfig{}).
+		WithName("custom").
+		WithSourceType(config.FileSource).
+		WithRevision("v1").
+		WithKeepOrder(false)
+
+	assert.Equal(t, "custom", coll.Name())
+	assert.Equal(t, config.FileSource, coll.Source())
+	assert.Equal(t, config.RevisionType("v1"), coll.Revision())
+	assert.False(t, coll.KeepOrder())
+}
+
+func TestStruct_Read(t *testing.T) {
+	t.Parallel()
+
+	data := structConfig{
+		Listen: "127.0.0.1:3301",
+		Log:    structLog{Level: "info", File: "/var/log/app.log"},
+		Server: structServer{Port: 8080, Hosts: []string{"a", "b"}, Skipped: "nope"},
+	}
+
+	coll := collectors.NewStruct(&data)
+	got := collectValues(t, coll.Read(context.Background()))
+
+	assert.Equal(t, "127.0.0.1:3301", got["listen"])
+	assert.Equal(t, "info", got["log/level"])
+	assert.Equal(t, "/var/log/app.log", got["log/file"])
+	assert.EqualValues(t, 8080, got["server/port"])
+	assert.NotContains(t, got, "server/skipped")
+	assert.NotContains(t, got, "server/private")
+}
+
+func TestStruct_Read_NotAStruct(t *testing.T) {
+	t.Parallel()
+
+	coll := collectors.NewStruct(42)
+	testutil.Drain(t, coll.Read(context.Background()))
+}
+
+func TestStruct_Read_Cancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	coll := collectors.NewStruct(structServer{Port: 1, Hosts: []string{"x"}})
+	valueCh := coll.Read(ctx)
+
+	_, ok := <-valueCh
+	require.True(t, ok)
+
+	cancel()
+	testutil.Drain(t, valueCh)
+}
+
+func TestStructToMap(t *testing.T) {
+	t.Parallel()
+
+	data := structConfig{
+		Listen: "addr",
+		Log:    structLog{Level: "debug", File: "f"},
+		Server: structServer{Port: 9, Hosts: []string{"h1"}},
+		Extra:  map[string]any{"k": "v"},
+		Tags:   map[int]string{1: "one"},
+		Nested: map[string]structLog{"x": {Level: "warn"}},
+	}
+
+	got, err := collectors.StructToMap(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, "addr", got["listen"])
+	assert.Equal(t, map[string]any{"level": "debug", "file": "f"}, got["log"])
+	assert.Equal(t, map[string]any{"port": 9, "hosts": []any{"h1"}}, got["server"])
+	assert.Equal(t, map[string]any{"k": "v"}, got["extra"])
+	assert.Equal(t, map[string]any{"1": "one"}, got["tags"])
+	assert.Equal(t, map[string]any{"x": map[string]any{"level": "warn", "file": ""}}, got["nested"])
+	assert.NotContains(t, got, "empty") // omitempty drops the zero value.
+}
+
+func TestStructToMap_PointerAndNotStruct(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectors.StructToMap(&structLog{Level: "err"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"level": "err", "file": ""}, got)
+
+	_, err = collectors.StructToMap("nope")
+	require.ErrorIs(t, err, collectors.ErrNotStruct)
+
+	_, err = collectors.StructToMap((*structLog)(nil))
+	require.ErrorIs(t, err, collectors.ErrNotStruct)
+}
+
+type inlineBase struct {
+	ID int `config:"id"`
+}
+
+type withInline struct {
+	inlineBase `config:",inline"`
+
+	Name    string         `config:"name"`
+	Meta    map[string]any `config:"meta,inline"`
+	Wrapped inlineBase     `config:"wrapped"`
+}
+
+func TestStructToMap_Inline(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectors.StructToMap(withInline{
+		inlineBase: inlineBase{ID: 7},
+		Name:       "n",
+		Meta:       map[string]any{"region": "eu"},
+		Wrapped:    inlineBase{ID: 8},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, got["id"])
+	assert.Equal(t, "n", got["name"])
+	assert.Equal(t, "eu", got["region"])
+	assert.Equal(t, map[string]any{"id": 8}, got["wrapped"])
+}
+
+type anonInner struct {
+	A int `config:"a"`
+}
+
+type anonOuter struct {
+	anonInner
+
+	B int `config:"b"`
+}
+
+func TestStructToMap_AnonymousNoInline(t *testing.T) {
+	t.Parallel()
+
+	got, err := collectors.StructToMap(anonOuter{anonInner: anonInner{A: 1}, B: 2})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"anoninner": map[string]any{"a": 1}, "b": 2}, got)
+}
+
+func TestStructToMap_Bytes(t *testing.T) {
+	t.Parallel()
+
+	type withBytes struct {
+		Raw []byte `config:"raw"`
+	}
+
+	got, err := collectors.StructToMap(withBytes{Raw: []byte("hi")})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hi"), got["raw"])
+}
+
+// collectValues drains a value channel into a map keyed by the slash-joined
+// key path.
+func collectValues(t *testing.T, valueCh <-chan config.Value) map[string]any {
+	t.Helper()
+
+	out := map[string]any{}
+
+	for value := range valueCh {
+		var dest any
+
+		require.NoError(t, value.Get(&dest))
+
+		out[value.Meta().Key.String()] = dest
+	}
+
+	return out
+}

--- a/example_collectors_test.go
+++ b/example_collectors_test.go
@@ -286,3 +286,55 @@ func Example_fileSource() {
 	// Port: 8080
 	// Log level: info
 }
+
+// Example_structCollector demonstrates the Struct collector which reads
+// configuration directly from a Go struct, using `config` (or `yaml`) tags
+// for key names.
+func Example_structCollector() {
+	type DB struct {
+		Host string `config:"host"`
+		Port int    `config:"port"`
+	}
+
+	type AppConfig struct {
+		Name  string `config:"name"`
+		DB    DB     `config:"db"`
+		Debug bool   `config:"debug,omitempty"`
+	}
+
+	collector := collectors.NewStruct(AppConfig{
+		Name: "myapp",
+		DB:   DB{Host: "localhost", Port: 5432},
+	}).WithName("defaults")
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collector)
+
+	cfg, errs := builder.Build(context.Background())
+	if len(errs) > 0 {
+		fmt.Printf("Build errors: %v\n", errs)
+		return
+	}
+
+	var name string
+
+	_, _ = cfg.Get(config.NewKeyPath("name"), &name)
+
+	var host string
+
+	_, _ = cfg.Get(config.NewKeyPath("db/host"), &host)
+
+	var port int
+
+	_, _ = cfg.Get(config.NewKeyPath("db/port"), &port)
+
+	fmt.Printf("name: %s\n", name)
+	fmt.Printf("db.host: %s\n", host)
+	fmt.Printf("db.port: %d\n", port)
+
+	// Output:
+	// name: myapp
+	// db.host: localhost
+	// db.port: 5432
+}


### PR DESCRIPTION
Adds a reflection-based `collectors.Struct` that reads configuration straight from a Go struct, alongside the standalone `collectors.StructToMap` helper that exposes the same conversion.

Field names come from the `config` struct tag, falling back to `yaml`, then the lowercased field name. The `-` directive skips a field, `omitempty` skips zero values, and `inline` merges a struct/map field's keys into the parent (anonymous fields without `inline` nest under the lowercased type name). Unexported fields are ignored except those promoted from an embedded struct. Internally the struct is turned into a `map[string]any` and flattened the same way as the `Map` collector, so it behaves consistently; key order is preserved by default like `YamlFormat`. Non-struct input yields no values from the collector, and `ErrNotStruct` from `StructToMap`.

Includes unit tests, a runnable example, doc updates, and a changelog entry.