### PR TITLE
config: resolve Effective by folding per-loader layer trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+* `Config.Effective`, `MutableConfig.Effective`, and `EffectiveAll` now
+  resolve a leaf entity by folding loaders in priority order (`env >
+  storage > file > env-default`, with runtime `MutableConfig` mutations
+  highest), so a higher-priority loader's value wins over a lower-priority
+  loader's value set at a deeper inheritance scope (`global → group →
+  replicaset → instance`). Previously scope depth always dominated loader
+  priority, which meant e.g. an env var routed to the global scope lost to
+  a YAML value set per instance. Single-collector configs and
+  global-scope-only keys are unaffected. This is a behavior change worth a
+  minor-version bump.
+
 ### Fixed
 
 ## [v1.2.0] - 2026-05-05

--- a/builder.go
+++ b/builder.go
@@ -156,7 +156,10 @@ func (b *Builder) WithInheritance(levels []string, opts ...InheritanceOption) Bu
 func (b *Builder) Build(ctx context.Context) (Config, []error) {
 	root := tree.New()
 
-	var errs []error
+	var (
+		errs   []error
+		layers []*tree.Node
+	)
 
 	merger := b.merger
 	if merger == nil {
@@ -170,40 +173,20 @@ func (b *Builder) Build(ctx context.Context) (Config, []error) {
 			continue
 		}
 
-		multiCol, isMulti := col.(MultiCollector)
-		if !isMulti {
-			err := MergeCollectorWithMerger(ctx, root, col, merger)
-			if err != nil {
-				errs = append(errs, err)
-			}
+		layer, layerErrs, ok := buildLayer(ctx, col, merger)
 
+		errs = append(errs, layerErrs...)
+
+		if !ok {
 			continue
 		}
 
-		subs, err := multiCol.Collectors(ctx)
-		if err != nil {
-			errs = append(errs, NewCollectorError(col.Name(), err))
-
-			continue
-		}
-
-		for j, sub := range subs {
-			if sub == nil {
-				errs = append(errs, NewCollectorError(col.Name(),
-					fmt.Errorf("%w at sub-index %d", ErrNilCollector, j)))
-
-				continue
-			}
-
-			err := MergeCollectorWithMerger(ctx, root, sub, merger)
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
+		layers = append(layers, layer)
+		mergeTreeInto(root, layer)
 	}
 
 	if len(errs) > 0 {
-		return Config{root: nil, inheritances: nil, validator: nil}, errs
+		return newConfig(nil, nil, nil), errs
 	}
 
 	if b.validator != nil && !b.skipValidation {
@@ -214,10 +197,52 @@ func (b *Builder) Build(ctx context.Context) (Config, []error) {
 	}
 
 	if len(errs) > 0 {
-		return Config{root: nil, inheritances: nil, validator: nil}, errs
+		return newConfig(nil, nil, nil), errs
 	}
 
-	return newConfig(root, b.inheritances, b.validator), nil
+	return newLayeredConfig(root, layers, b.inheritances, b.validator), nil
+}
+
+// buildLayer merges one top-level collector into a fresh layer tree. For a
+// MultiCollector it expands the sub-collectors and merges each in order.
+// The third result is false only when the collector could not be expanded at
+// all (the MultiCollector.Collectors call failed); per-sub errors are
+// collected but the layer is still returned.
+func buildLayer(ctx context.Context, col Collector, merger Merger) (*tree.Node, []error, bool) {
+	layer := tree.New()
+
+	var errs []error
+
+	multiCol, isMulti := col.(MultiCollector)
+	if !isMulti {
+		err := MergeCollectorWithMerger(ctx, layer, col, merger)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		return layer, errs, true
+	}
+
+	subs, err := multiCol.Collectors(ctx)
+	if err != nil {
+		return nil, []error{NewCollectorError(col.Name(), err)}, false
+	}
+
+	for j, sub := range subs {
+		if sub == nil {
+			errs = append(errs, NewCollectorError(col.Name(),
+				fmt.Errorf("%w at sub-index %d", ErrNilCollector, j)))
+
+			continue
+		}
+
+		err := MergeCollectorWithMerger(ctx, layer, sub, merger)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return layer, errs, true
 }
 
 // BuildMutable starts the configuration assembly process but returns
@@ -225,7 +250,7 @@ func (b *Builder) Build(ctx context.Context) (Config, []error) {
 func (b *Builder) BuildMutable(ctx context.Context) (MutableConfig, []error) {
 	cfg, errs := b.Build(ctx)
 	if len(errs) > 0 {
-		return MutableConfig{Config: Config{root: nil, inheritances: nil, validator: nil}, mu: sync.RWMutex{}}, errs
+		return MutableConfig{Config: newConfig(nil, nil, nil), mu: sync.RWMutex{}}, errs
 	}
 
 	return MutableConfig{Config: cfg, mu: sync.RWMutex{}}, nil

--- a/config.go
+++ b/config.go
@@ -114,11 +114,73 @@ type Config struct {
 	// invoked on demand by [Config.Validate] (and, for MutableConfig,
 	// by Set/Merge/Update via validateOrRestore).
 	validator validator.Validator
+
+	// layers holds the per-loader layer trees produced by Builder.Build, one
+	// per top-level collector (or MultiCollector) in ascending-priority order.
+	// Nil for configs not produced by Builder (slices, Walk/effective sub-configs).
+	layers []*tree.Node
+
+	// modified holds runtime mutations applied by MutableConfig; nil until the
+	// first mutation.
+	modified *tree.Node
+
+	// tombstones records key paths deleted via MutableConfig.Delete.
+	tombstones []keypath.KeyPath
+}
+
+// entityTombstoned reports whether entityPath, or one of its ancestor scopes,
+// was deleted via MutableConfig.Delete (any tombstone that prefixes entityPath).
+func entityTombstoned(tombstones []keypath.KeyPath, entityPath keypath.KeyPath) bool {
+	for _, tomb := range tombstones {
+		if len(tomb) > len(entityPath) {
+			continue
+		}
+
+		match := true
+
+		for i, seg := range tomb {
+			if entityPath[i] != seg {
+				match = false
+				break
+			}
+		}
+
+		if match {
+			return true
+		}
+	}
+
+	return false
 }
 
 // newConfig creates a Config from a tree node.
 func newConfig(root *tree.Node, inheritances []inheritanceConfig, val validator.Validator) Config {
-	return Config{root: root, inheritances: inheritances, validator: val}
+	return Config{
+		root:         root,
+		inheritances: inheritances,
+		validator:    val,
+		layers:       nil,
+		modified:     nil,
+		tombstones:   nil,
+	}
+}
+
+// newLayeredConfig creates a Config that carries per-loader layer trees in
+// addition to the merged root. Used by Builder.Build.
+func newLayeredConfig(
+	root *tree.Node,
+	layers []*tree.Node,
+	inheritances []inheritanceConfig,
+	val validator.Validator,
+) Config {
+	return Config{
+		root:         root,
+		inheritances: inheritances,
+		validator:    val,
+		layers:       layers,
+		modified:     nil,
+		tombstones:   nil,
+	}
 }
 
 // Get is the primary, most convenient method for retrieving a value.
@@ -312,14 +374,14 @@ func (c *Config) Effective(path KeyPath) (Config, error) {
 	for i := range c.inheritances {
 		inheritanceCfg := &c.inheritances[i]
 
-		layers, ok := matchHierarchy(c.root, inheritanceCfg, path)
-		if !ok {
-			continue
+		resolved, matched, tombstoned := c.resolveEntityConfig(inheritanceCfg, path)
+		if tombstoned {
+			return Config{}, fmt.Errorf("%w: %s", ErrPathNotFound, path)
 		}
 
-		result := resolveEffective(layers, inheritanceCfg)
-
-		return newConfig(result, c.inheritances, nil), nil
+		if matched {
+			return resolved, nil
+		}
 	}
 
 	// No hierarchy matched — fall back to raw subtree.
@@ -348,6 +410,58 @@ func (c *Config) EffectiveAll() (map[string]Config, error) {
 	}
 
 	return result, nil
+}
+
+// deepClone returns an independent copy: root, layers, modified and tombstones
+// are copied; inheritances and validator are shared (read-only after Build).
+func (c *Config) deepClone() Config {
+	clonedLayers := make([]*tree.Node, len(c.layers))
+	for i, layer := range c.layers {
+		clonedLayers[i] = cloneNode(layer)
+	}
+
+	clonedTombstones := make([]keypath.KeyPath, len(c.tombstones))
+	for i, kp := range c.tombstones {
+		clonedTombstones[i] = append(keypath.KeyPath{}, kp...)
+	}
+
+	return Config{
+		root:         cloneNode(c.root),
+		inheritances: c.inheritances,
+		validator:    c.validator,
+		layers:       clonedLayers,
+		modified:     cloneNode(c.modified),
+		tombstones:   clonedTombstones,
+	}
+}
+
+// resolveEntityConfig resolves the effective Config for entityPath under
+// inheritanceCfg. It returns the resolved config (meaningful only when matched),
+// whether entityPath fits the hierarchy, and whether it (or an ancestor scope)
+// was deleted via MutableConfig.Delete (in which case matched is false).
+func (c *Config) resolveEntityConfig(
+	inheritanceCfg *inheritanceConfig,
+	entityPath keypath.KeyPath,
+) (Config, bool, bool) {
+	if len(c.layers) == 0 {
+		// Not produced by a Builder: single merged-tree resolution.
+		layers, ok := matchHierarchy(c.root, inheritanceCfg, entityPath)
+		if !ok {
+			return newConfig(nil, nil, nil), false, false
+		}
+
+		return newConfig(resolveEffective(layers, inheritanceCfg), c.inheritances, nil), true, false
+	}
+
+	if _, ok := matchHierarchy(c.root, inheritanceCfg, entityPath); !ok {
+		return newConfig(nil, nil, nil), false, false
+	}
+
+	if entityTombstoned(c.tombstones, entityPath) {
+		return newConfig(nil, nil, nil), false, true
+	}
+
+	return newConfig(resolveEffectiveLayered(c, inheritanceCfg, entityPath), c.inheritances, nil), true, false
 }
 
 // collectLeafEntities recursively finds all leaf entities in the hierarchy
@@ -382,14 +496,12 @@ func (c *Config) collectLeafEntities(
 		for _, name := range structNode.ChildrenKeys() {
 			entityPath := currentPath.Append(structKey, name)
 
-			layers, ok := matchHierarchy(c.root, inheritanceCfg, entityPath)
-			if !ok {
+			resolved, matched, _ := c.resolveEntityConfig(inheritanceCfg, entityPath)
+			if !matched {
 				continue
 			}
 
-			resolved := resolveEffective(layers, inheritanceCfg)
-
-			result[entityPath.String()] = newConfig(resolved, c.inheritances, nil)
+			result[entityPath.String()] = resolved
 		}
 
 		return
@@ -514,7 +626,7 @@ func (mc *MutableConfig) Snapshot() Config {
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()
 
-	return newConfig(cloneNode(mc.root), mc.inheritances, mc.validator)
+	return mc.deepClone()
 }
 
 // Set sets or overwrites a value at the specified path.
@@ -534,6 +646,14 @@ func (mc *MutableConfig) Set(path KeyPath, value any) error {
 	}
 
 	markModified(mc.root.Get(path))
+
+	// Record the mutation in the runtime overlay (it outranks every loader).
+	if mc.modified == nil {
+		mc.modified = tree.New()
+	}
+
+	mc.modified.Set(path, value)
+	markModified(mc.modified.Get(path))
 
 	return nil
 }
@@ -594,8 +714,15 @@ func (mc *MutableConfig) Merge(other *Config) error {
 		return restoreErr
 	}
 
+	// Record the mutations in the runtime overlay (it outranks every loader).
+	if mc.modified == nil {
+		mc.modified = tree.New()
+	}
+
 	for _, mergeEntry := range ops {
 		markModified(mc.root.Get(mergeEntry.path))
+		mc.modified.Set(mergeEntry.path, mergeEntry.value)
+		markModified(mc.modified.Get(mergeEntry.path))
 	}
 
 	return nil
@@ -615,7 +742,7 @@ func (mc *MutableConfig) Update(other *Config) error {
 
 	oldRoot := cloneNode(mc.root)
 
-	var applied []keypath.KeyPath
+	var applied []mergeOp
 
 	for _, updateEntry := range ops {
 		if mc.root.Get(updateEntry.path) == nil {
@@ -624,7 +751,7 @@ func (mc *MutableConfig) Update(other *Config) error {
 
 		mc.root.Set(updateEntry.path, updateEntry.value)
 
-		applied = append(applied, updateEntry.path)
+		applied = append(applied, updateEntry)
 	}
 
 	restoreErr := mc.validateOrRestore(oldRoot)
@@ -632,8 +759,15 @@ func (mc *MutableConfig) Update(other *Config) error {
 		return restoreErr
 	}
 
-	for _, path := range applied {
-		markModified(mc.root.Get(path))
+	// Record the mutations in the runtime overlay (it outranks every loader).
+	if len(applied) > 0 && mc.modified == nil {
+		mc.modified = tree.New()
+	}
+
+	for _, op := range applied {
+		markModified(mc.root.Get(op.path))
+		mc.modified.Set(op.path, op.value)
+		markModified(mc.modified.Get(op.path))
 	}
 
 	return nil
@@ -659,32 +793,21 @@ func (mc *MutableConfig) Delete(path KeyPath) bool {
 
 	oldRoot := cloneNode(mc.root)
 
-	// Cascade delete the target subtree, then walk back up removing
-	// any ancestors that became empty as a result.
-	for i := len(path); i > 0; i-- {
-		parentPath := path[:i-1]
-		childKey := path[i-1]
-
-		parent := mc.root.Get(parentPath)
-		if parent == nil {
-			break
-		}
-
-		if !parent.DeleteChild(childKey) {
-			break
-		}
-
-		// Stop climbing once we reach the root, or an ancestor that still
-		// holds something (remaining children, or a scalar value).
-		// The root itself is never removed.
-		if len(parentPath) == 0 || !parent.IsLeaf() || parent.Value != nil {
-			break
-		}
-	}
+	// Cascade delete the target subtree and prune empty ancestors.
+	pruneTreePath(mc.root, path)
 
 	restoreErr := mc.validateOrRestore(oldRoot)
+	if restoreErr != nil {
+		return false
+	}
 
-	return restoreErr == nil
+	// Keep the overlay consistent with the live tree.
+	pruneTreePath(mc.modified, path)
+
+	// Record a tombstone so resolveEffectiveLayered suppresses this path in every layer.
+	mc.tombstones = append(mc.tombstones, append(keypath.KeyPath{}, path...))
+
+	return true
 }
 
 // validateOrRestore validates the current tree and restores the old root on failure.

--- a/config_test.go
+++ b/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/meta"
 )
 
 func TestConfig_Stat_ExistingKey(t *testing.T) {
@@ -919,4 +920,364 @@ func TestMutableConfig_Snapshot_KeyAddedAfterSnapshotInvisible(t *testing.T) {
 
 	_, ok := snap.Lookup(config.NewKeyPath("added"))
 	assert.False(t, ok, "snapshot should not observe keys added after Snapshot()")
+}
+
+// buildLayeredMutable builds a MutableConfig with two collectors and inheritance.
+// Collector 1 (lower priority): sets replication.failover=manual at global scope.
+// Collector 2 (higher priority): sets replication.failover=election at instance scope.
+// Hierarchy: Global → groups → replicasets → instances.
+func buildLayeredMutable(t *testing.T) *config.MutableConfig {
+	t.Helper()
+
+	builder := config.NewBuilder()
+
+	// Lower-priority loader: global-scope key.
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("file"))
+
+	// Higher-priority loader: instance-scope override of the same key.
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"replication": map[string]any{"failover": "election"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("env"))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	return &cfg
+}
+
+func TestMutableConfig_Layered_Set_SourceIsModified(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Set overwrites a key at the global scope.
+	require.NoError(t, cfg.Set(config.NewKeyPath("replication/failover"), "supervised"))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	metaInfo, err := eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+
+	// IV3, IV4: the Set value must appear and carry Source=modified.
+	assert.Equal(t, "supervised", failover)
+	assert.Equal(t, meta.ModifiedSourceName, metaInfo.Source.Name, "Source must be %q", meta.ModifiedSourceName)
+
+	// EffectiveAll must reflect the same value.
+	all, err := cfg.EffectiveAll()
+	require.NoError(t, err)
+
+	effFromAll, ok := all["groups/storages/replicasets/s-001/instances/s-001-a"]
+	require.True(t, ok)
+
+	var failoverAll string
+
+	_, err = effFromAll.Get(config.NewKeyPath("replication/failover"), &failoverAll)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", failoverAll)
+}
+
+func TestMutableConfig_Layered_Delete_FallsBackToScopedLoaderValue(t *testing.T) {
+	t.Parallel()
+
+	// The "file" loader sets replication.failover=manual at the global scope; the
+	// "env" loader sets it to "election" at the instance scope. Deleting the key
+	// tombstones the global-scope contribution, so the instance-scope value survives.
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	require.True(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "election", failover)
+}
+
+func TestMutableConfig_Layered_Delete_LastContribution_DefaultVisible(t *testing.T) {
+	t.Parallel()
+
+	// Single loader with a default, set only at global scope.
+	// After deleting the only concrete contribution, the inheritance default must appear.
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("file"))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithDefaults(config.DefaultsType{
+			"replication": map[string]any{"failover": "off"},
+		}),
+	)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	// Verify baseline.
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+	eff0, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var base string
+
+	_, err = eff0.Get(config.NewKeyPath("replication/failover"), &base)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", base)
+
+	// Delete the concrete contribution.
+	require.True(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+	// Now the default must shine through.
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "off", failover, "default must be visible after deleting the only concrete contribution")
+}
+
+func TestMutableConfig_Layered_Delete_WholeEntity_ErrPathNotFound(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Verify the entity exists before deletion.
+	_, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	// Delete the whole instance entity node from the merged root.
+	require.True(t, cfg.Delete(config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")))
+
+	// Effective must now return ErrPathNotFound.
+	_, err = cfg.Effective(leafPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, config.ErrPathNotFound, "expected ErrPathNotFound, got: %v", err)
+}
+
+func TestMutableConfig_Layered_Snapshot_EffectiveConsistent(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Apply a Set mutation to override what the env loader contributed.
+	require.NoError(t, cfg.Set(config.NewKeyPath("replication/failover"), "supervised"))
+
+	// Take a snapshot after the mutation.
+	snap := cfg.Snapshot()
+
+	// Snapshot Effective must equal live Effective at this point.
+	liveEff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	snapEff, err := snap.Effective(leafPath)
+	require.NoError(t, err)
+
+	var liveVal, snapVal string
+
+	_, err = liveEff.Get(config.NewKeyPath("replication/failover"), &liveVal)
+	require.NoError(t, err)
+
+	_, err = snapEff.Get(config.NewKeyPath("replication/failover"), &snapVal)
+	require.NoError(t, err)
+	assert.Equal(t, liveVal, snapVal, "Snapshot Effective must match live Effective")
+	assert.Equal(t, "supervised", snapVal)
+
+	// Delete the key from the live config.
+	require.True(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+	// Snapshot must still resolve the pre-deletion value.
+	snapEff2, err := snap.Effective(leafPath)
+	require.NoError(t, err)
+
+	var afterDelete string
+
+	_, err = snapEff2.Get(config.NewKeyPath("replication/failover"), &afterDelete)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", afterDelete, "snapshot Effective must be frozen and unaffected by live Delete")
+}
+
+func TestMutableConfig_Layered_Delete_GetEffectiveConsistent(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Delete a key that exists.
+	require.True(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+	// Get on the root must not see the deleted key at the root level.
+	// (The env loader's instance-scope value was merged into root, now deleted.)
+	_, ok := cfg.Lookup(config.NewKeyPath("replication/failover"))
+	assert.False(t, ok, "Get must not see the deleted key (IV2: root is authoritative for non-Effective reads)")
+
+	// Effective sees the surviving contribution (env loader's instance-scope fallback).
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "election", failover, "Effective must see the instance-scoped value from the env layer")
+}
+
+func TestMutableConfig_Layered_DeleteThenSet_ValueReappears(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+	keyPath := config.NewKeyPath("replication/failover")
+
+	// Delete the key, then re-Set it. The re-Set value must reappear in Effective
+	// with Source=modified — the Delete tombstone must not keep suppressing it.
+	require.True(t, cfg.Delete(keyPath))
+	require.NoError(t, cfg.Set(keyPath, "supervised"))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	metaInfo, err := eff.Get(keyPath, &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", failover, "re-Set value must win over the cleared Delete tombstone")
+	assert.Equal(t, meta.ModifiedSourceName, metaInfo.Source.Name)
+
+	// Get on the root and Effective must agree.
+	var rootVal string
+
+	_, err = cfg.Get(keyPath, &rootVal)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", rootVal)
+}
+
+func TestMutableConfig_Layered_SetDeleteSet_LastSetWins(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+	keyPath := config.NewKeyPath("replication/failover")
+
+	require.NoError(t, cfg.Set(keyPath, "first"))
+	require.True(t, cfg.Delete(keyPath))
+	require.NoError(t, cfg.Set(keyPath, "second"))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(keyPath, &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "second", failover)
+}
+
+func TestMutableConfig_Layered_InsertChild_DeleteParent_InsertSibling(t *testing.T) {
+	t.Parallel()
+
+	// A loader contributes a sibling under the parent that gets deleted.
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"a": map[string]any{"loaderkey": "loader"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file"))
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	require.NoError(t, cfg.Set(config.NewKeyPath("a/b"), "v1"))
+	require.True(t, cfg.Delete(config.NewKeyPath("a")))
+	require.NoError(t, cfg.Set(config.NewKeyPath("a/c"), "v2"))
+
+	// After "delete a", only "a/c" exists; "a/b" and the loader's "a/loaderkey"
+	// are gone — and Effective must agree with the raw view on all three.
+	_, okB := cfg.Lookup(config.NewKeyPath("a/b"))
+	_, okC := cfg.Lookup(config.NewKeyPath("a/c"))
+	_, okL := cfg.Lookup(config.NewKeyPath("a/loaderkey"))
+
+	require.False(t, okB)
+	require.True(t, okC)
+	require.False(t, okL)
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var valB, valC, valLoader string
+
+	_, errB := eff.Get(config.NewKeyPath("a/b"), &valB)
+	metaC, errC := eff.Get(config.NewKeyPath("a/c"), &valC)
+	_, errLoader := eff.Get(config.NewKeyPath("a/loaderkey"), &valLoader)
+
+	require.Error(t, errB, "Effective must not resurrect a/b after delete a")
+	require.NoError(t, errC)
+	assert.Equal(t, "v2", valC)
+	assert.Equal(t, meta.ModifiedSourceName, metaC.Source.Name)
+	require.Error(t, errLoader, "Effective must not resurrect the loader's a/loaderkey after delete a")
 }

--- a/inheritance.go
+++ b/inheritance.go
@@ -341,6 +341,82 @@ func (inheritanceCfg *inheritanceConfig) hasSubStrategies(prefix string) bool {
 	return false
 }
 
+// foldScopeChainInto folds one layer's scope chain (the global→…→instance
+// nodes returned by matchHierarchy, any of which may be nil) into result,
+// applying inheritance rules. suppressedByLevel optionally lists, per level,
+// key paths to prune before folding (tombstone suppression); nil disables it.
+func foldScopeChainInto(
+	result *tree.Node,
+	scopeChain []*tree.Node,
+	inheritanceCfg *inheritanceConfig,
+	suppressedByLevel map[int][]keypath.KeyPath,
+) {
+	for levelIdx, layer := range scopeChain {
+		if layer == nil {
+			continue
+		}
+
+		// Apply per-level pruning (tombstone suppression) if requested.
+		if len(suppressedByLevel[levelIdx]) > 0 {
+			layer = cloneNode(layer)
+			for _, kp := range suppressedByLevel[levelIdx] {
+				pruneTreePath(layer, kp)
+			}
+		}
+
+		for _, key := range layer.ChildrenKeys() {
+			keyPath := keypath.NewKeyPath(key)
+
+			// Skip structural keys (groups, replicasets, instances, …).
+			if isStructuralKey(inheritanceCfg, key) {
+				continue
+			}
+
+			// Apply exclusion rules.
+			if !inheritanceCfg.shouldInherit(levelIdx, keyPath) {
+				// Only include at the LEAF level (last entry in the chain).
+				if levelIdx < len(scopeChain)-1 {
+					continue
+				}
+			}
+
+			child := layer.Child(key)
+			mergeIntoResultWithStrategies(result, key, child, inheritanceCfg)
+		}
+	}
+}
+
+// pruneTreePath removes the node at path from root, then walks back up removing
+// any ancestor that became empty as a result.  A nil root, an empty path, or a
+// path that is not present is a no-op.
+func pruneTreePath(root *tree.Node, path keypath.KeyPath) {
+	if root == nil || len(path) == 0 {
+		return
+	}
+
+	if root.Get(path) == nil {
+		return
+	}
+
+	for i := len(path); i > 0; i-- {
+		parentPath := path[:i-1]
+		childKey := path[i-1]
+
+		parent := root.Get(parentPath)
+		if parent == nil {
+			break
+		}
+
+		if !parent.DeleteChild(childKey) {
+			break
+		}
+
+		if len(parentPath) == 0 || !parent.IsLeaf() || parent.Value != nil {
+			break
+		}
+	}
+}
+
 // resolveEffective merges layers from global to leaf with inheritance rules.
 func resolveEffective(layers []*tree.Node, inheritanceCfg *inheritanceConfig) *tree.Node {
 	result := tree.New()
@@ -350,32 +426,142 @@ func resolveEffective(layers []*tree.Node, inheritanceCfg *inheritanceConfig) *t
 		mergeDefaults(result, inheritanceCfg.defaults)
 	}
 
-	// Merge each layer in order (global first, leaf last = highest priority).
-	for levelIdx, layer := range layers {
-		if layer == nil {
-			continue
+	foldScopeChainInto(result, layers, inheritanceCfg, nil)
+
+	return result
+}
+
+// accumulateLayerResult folds the higher-priority layer srcLayer into dst.
+// MergeAppend/MergeDeep keys use their configured strategy. MergeReplace keys
+// replace the dst value, except that two map nodes are merged recursively so a
+// loader that sets only one sub-key does not drop sibling sub-keys contributed
+// by a lower-priority loader.
+func accumulateLayerResult(dst, srcLayer *tree.Node, inheritanceCfg *inheritanceConfig) {
+	for _, key := range srcLayer.ChildrenKeys() {
+		src := srcLayer.Child(key)
+		strategy, _ := inheritanceCfg.strategyFor(key)
+
+		switch strategy {
+		case MergeAppend, MergeDeep:
+			mergeIntoResultWithStrategies(dst, key, src, inheritanceCfg)
+
+		case MergeReplace:
+			if dstChild := dst.Child(key); isMapNode(dstChild) && isMapNode(src) {
+				mergeTreeInto(dstChild, src)
+			} else {
+				dst.SetChild(key, cloneNode(src))
+			}
 		}
+	}
+}
 
-		for _, key := range layer.ChildrenKeys() {
-			keyPath := keypath.NewKeyPath(key)
+// buildSuppressedByLevel maps each tombstone to the inheritance level it was
+// deleted from: the longest per-level prefix of entityPath that prefixes the
+// tombstone; the remaining config-key suffix is what gets suppressed at that
+// level. Whole-entity/whole-scope deletes (empty suffix) and structural-key
+// suffixes are left out — those are handled by the entityTombstoned guard.
+func buildSuppressedByLevel(
+	tombstones []keypath.KeyPath,
+	inheritanceCfg *inheritanceConfig,
+	entityPath keypath.KeyPath,
+) map[int][]keypath.KeyPath {
+	if len(tombstones) == 0 {
+		return nil
+	}
 
-			// Skip structural keys.
-			if isStructuralKey(inheritanceCfg, key) {
+	numLevels := len(inheritanceCfg.levels)
+
+	// Pre-compute scope paths for each level: entityPath[:levelIdx*segmentsPerLevel].
+	scopePaths := make([]keypath.KeyPath, numLevels)
+	for i := range numLevels {
+		scopePaths[i] = entityPath[:i*segmentsPerLevel]
+	}
+
+	var result map[int][]keypath.KeyPath
+
+	for _, tomb := range tombstones {
+		// Find the longest scope prefix (highest level index) that prefixes tomb.
+		bestLevel := -1
+
+		for i := numLevels - 1; i >= 0; i-- {
+			scopePath := scopePaths[i]
+			if len(scopePath) > len(tomb) {
 				continue
 			}
 
-			// Apply exclusion rules.
-			if !inheritanceCfg.shouldInherit(levelIdx, keyPath) {
-				// Only include if this is the level where it was explicitly set.
-				// For WithNoInherit: only at the LEAF level (last layer).
-				// For WithNoInheritFrom: skip only from the excluded level.
-				if levelIdx < len(layers)-1 {
-					continue
+			match := true
+
+			for j, seg := range scopePath {
+				if tomb[j] != seg {
+					match = false
+					break
 				}
 			}
 
-			child := layer.Child(key)
-			mergeIntoResultWithStrategies(result, key, child, inheritanceCfg)
+			if match {
+				bestLevel = i
+				break
+			}
+		}
+
+		if bestLevel < 0 {
+			continue
+		}
+
+		cfgKey := tomb[len(scopePaths[bestLevel]):]
+
+		if len(cfgKey) == 0 {
+			continue // whole-entity/whole-scope delete: see entityTombstoned.
+		}
+
+		if isStructuralKey(inheritanceCfg, cfgKey[0]) {
+			continue // hierarchy structure, not a config key.
+		}
+
+		if result == nil {
+			result = make(map[int][]keypath.KeyPath)
+		}
+
+		result[bestLevel] = append(result[bestLevel], cfgKey)
+	}
+
+	return result
+}
+
+// resolveEffectiveLayered resolves the effective config for entityPath by
+// resolving each layer's scope chain independently (so scope-depth inheritance
+// applies within a layer) and accumulating the per-layer results in ascending
+// priority order, so a higher-priority loader's value wins regardless of which
+// inheritance scope it sits in. cfg.modified, if any, is folded last (runtime
+// mutations outrank every loader). suppressedByLevel, built from cfg.tombstones,
+// prunes runtime-deleted keys from each layer's scope chain; it is not applied
+// to cfg.modified, which Delete prunes directly.
+func resolveEffectiveLayered(cfg *Config, inheritanceCfg *inheritanceConfig, entityPath keypath.KeyPath) *tree.Node {
+	result := tree.New()
+
+	if inheritanceCfg.defaults != nil {
+		mergeDefaults(result, inheritanceCfg.defaults)
+	}
+
+	suppressedByLevel := buildSuppressedByLevel(cfg.tombstones, inheritanceCfg, entityPath)
+
+	for _, layer := range cfg.layers {
+		scopeChain, ok := matchHierarchy(layer, inheritanceCfg, entityPath)
+		if !ok {
+			continue
+		}
+
+		layerResult := tree.New()
+		foldScopeChainInto(layerResult, scopeChain, inheritanceCfg, suppressedByLevel)
+		accumulateLayerResult(result, layerResult, inheritanceCfg)
+	}
+
+	if cfg.modified != nil {
+		scopeChain, ok := matchHierarchy(cfg.modified, inheritanceCfg, entityPath)
+		if ok {
+			modResult := tree.New()
+			foldScopeChainInto(modResult, scopeChain, inheritanceCfg, nil)
+			accumulateLayerResult(result, modResult, inheritanceCfg)
 		}
 	}
 

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -1323,6 +1323,261 @@ func TestConfig_Walk_ContextCancellation(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Layered Effective / EffectiveAll tests
+// ---------------------------------------------------------------------------.
+
+// TestLayered_LoaderPriorityBeatsScope verifies that a value set at the global
+// scope in a higher-priority loader overrides a value set at the instance scope
+// in a lower-priority loader (IV1).  This is the "audit_log/extract_key" class
+// of bug: instance-scope in loader-A must lose to global-scope in loader-B when
+// loader-B has higher priority.
+// The test also checks that Stat reports the source of the winning value (PC1).
+func TestLayered_LoaderPriorityBeatsScope(t *testing.T) {
+	t.Parallel()
+
+	// Loader 1 (lower priority): sets audit_log/extract_key at instance scope.
+	loader1 := collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"audit_log": map[string]any{
+									"extract_key": "instance-value",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("loader1").WithSourceType(config.FileSource)
+
+	// Loader 2 (higher priority): sets audit_log/extract_key at global scope.
+	loader2 := collectors.NewMap(map[string]any{
+		"audit_log": map[string]any{
+			"extract_key": "global-override",
+		},
+	}).WithName("loader2").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(loader1) // lower priority.
+	builder = builder.AddCollector(loader2) // higher priority.
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var val string
+
+	_, err = eff.Get(config.NewKeyPath("audit_log/extract_key"), &val)
+	require.NoError(t, err)
+	// Loader2 (global scope, higher priority) must win over loader1 (instance scope).
+	assert.Equal(t, "global-override", val,
+		"higher-priority loader global value must beat lower-priority loader instance value")
+
+	// PC1: Stat must report the originating source (loader2).
+	// Note: SourceType is not stored in tree nodes; only the collector name is.
+	meta, ok := eff.Stat(config.NewKeyPath("audit_log/extract_key"))
+	require.True(t, ok)
+	assert.Equal(t, "loader2", meta.Source.Name,
+		"Stat must report the source name of the winning value")
+}
+
+// TestLayered_MergeAppendAcrossLoaders verifies that MergeAppend composes
+// across loader boundaries (values from different loaders are appended).
+func TestLayered_MergeAppendAcrossLoaders(t *testing.T) {
+	t.Parallel()
+
+	// Loader 1: roles at global scope.
+	loader1 := collectors.NewMap(map[string]any{
+		"roles": []any{"storage"},
+	}).WithName("loader1").WithSourceType(config.FileSource)
+
+	// Loader 2 (higher priority): roles at global scope — should append.
+	loader2 := collectors.NewMap(map[string]any{
+		"roles": []any{"metrics"},
+	}).WithName("loader2").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(loader1)
+	builder = builder.AddCollector(loader2)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("roles", config.MergeAppend),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	// Any leaf path works; there's no explicit instances, so use nonexistent
+	// (matchHierarchy returns ok=true, all nodes nil except global).
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var roles []string
+
+	_, err = eff.Get(config.NewKeyPath("roles"), &roles)
+	require.NoError(t, err)
+	// Loader1 provides ["storage"], loader2 provides ["metrics"].
+	// With MergeAppend both should appear, loader1 first (lower priority), loader2 second.
+	assert.Equal(t, []string{"storage", "metrics"}, roles)
+}
+
+// TestLayered_MergeDeepAcrossLoaders verifies that MergeDeep composes across
+// loader boundaries (users from both loaders are present in effective config).
+func TestLayered_MergeDeepAcrossLoaders(t *testing.T) {
+	t.Parallel()
+
+	// Loader 1: user "admin" at global scope.
+	loader1 := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"admin": map[string]any{"password": "secret"},
+			},
+		},
+	}).WithName("loader1").WithSourceType(config.FileSource)
+
+	// Loader 2 (higher priority): user "monitor" at global scope.
+	loader2 := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"monitor": map[string]any{"password": "mon"},
+			},
+		},
+	}).WithName("loader2").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(loader1)
+	builder = builder.AddCollector(loader2)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("credentials", config.MergeDeep),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var users map[string]any
+
+	_, err = eff.Get(config.NewKeyPath("credentials/users"), &users)
+	require.NoError(t, err)
+	assert.Contains(t, users, "admin", "admin user from loader1 must be present")
+	assert.Contains(t, users, "monitor", "monitor user from loader2 must be present")
+}
+
+// TestLayered_SingleCollector_ScopeDepthUnchanged ensures that when only one
+// collector is used, scope-depth precedence is preserved (AS3): the more
+// specific (leaf) scope wins over the global scope within that collector.
+func TestLayered_SingleCollector_ScopeDepthUnchanged(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replication": map[string]any{"failover": "election"},
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("single").WithSourceType(config.FileSource))
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	// Group level (more specific) must override global level within the same loader.
+	assert.Equal(t, "election", failover,
+		"scope-depth precedence must be preserved with a single collector")
+}
+
+// TestLayered_EffectiveAll_LoaderPriorityBeatsScope verifies that EffectiveAll
+// applies the same loader-priority-over-scope resolution for every leaf.
+func TestLayered_EffectiveAll_LoaderPriorityBeatsScope(t *testing.T) {
+	t.Parallel()
+
+	loader1 := collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"mode": "instance-value",
+							},
+							"s-001-b": map[string]any{
+								"mode": "instance-value",
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("loader1").WithSourceType(config.FileSource)
+
+	loader2 := collectors.NewMap(map[string]any{
+		"mode": "global-override",
+	}).WithName("loader2").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(loader1)
+	builder = builder.AddCollector(loader2)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	all, err := cfg.EffectiveAll()
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+
+	for path, eff := range all {
+		var mode string
+
+		_, err := eff.Get(config.NewKeyPath("mode"), &mode)
+		require.NoError(t, err, "leaf %s", path)
+		assert.Equal(t, "global-override", mode,
+			"higher-priority loader global value must beat instance-scope value for leaf %s", path)
+	}
+}
+
 func TestWithInheritance_YamlArrayPreserved(t *testing.T) {
 	t.Parallel()
 

--- a/layered_extra_test.go
+++ b/layered_extra_test.go
@@ -1,0 +1,507 @@
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/meta"
+)
+
+// ---------------------------------------------------------------------------
+// Cross-loader MergeReplace map-recursion through Effective
+// ---------------------------------------------------------------------------.
+
+// TestLayered_CrossLoader_NonConflictingSubkeysCoexist is the headline
+// invariant of accumulateLayerResult: a higher-priority loader that only sets
+// one sub-key of a map must not wipe out sibling sub-keys contributed by a
+// lower-priority loader. (file loader sets replication/failover, env loader
+// sets replication/timeout — both must survive in the effective view.)
+func TestLayered_CrossLoader_NonConflictingSubkeysCoexist(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "election"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"replication": map[string]any{"timeout": 30},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader) // lower priority.
+	builder = builder.AddCollector(envLoader)  // higher priority.
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "election", failover, "lower-priority sub-key must survive")
+
+	var timeout int
+
+	_, err = eff.Get(config.NewKeyPath("replication/timeout"), &timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 30, timeout, "higher-priority sub-key must be present")
+}
+
+// TestLayered_CrossLoader_ConflictingSubkeyHigherPriorityWins verifies that
+// when both loaders set the same sub-key, the higher-priority loader wins while
+// non-conflicting sub-keys from the lower-priority loader still coexist.
+func TestLayered_CrossLoader_ConflictingSubkeyHigherPriorityWins(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual", "timeout": 10},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "election"},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader)
+	builder = builder.AddCollector(envLoader)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var failover string
+
+	fMeta, err := eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "election", failover)
+	assert.Equal(t, "env", fMeta.Source.Name)
+
+	var timeout int
+
+	tMeta, err := eff.Get(config.NewKeyPath("replication/timeout"), &timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 10, timeout)
+	assert.Equal(t, "file", tMeta.Source.Name)
+}
+
+// TestLayered_CrossLoader_TypeMismatchHigherPriorityReplaces verifies that when
+// a higher-priority loader provides a value of a different shape (scalar vs
+// map), the higher-priority loader replaces the lower-priority contribution
+// wholesale (no attempt to merge incompatible nodes).
+func TestLayered_CrossLoader_TypeMismatchHigherPriorityReplaces(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"thing": map[string]any{"a": 1, "b": 2},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"thing": "scalar",
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader)
+	builder = builder.AddCollector(envLoader)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var thing string
+
+	_, err = eff.Get(config.NewKeyPath("thing"), &thing)
+	require.NoError(t, err)
+	assert.Equal(t, "scalar", thing)
+
+	// The lower-priority map sub-keys must be gone — they were replaced, not merged.
+	_, err = eff.Get(config.NewKeyPath("thing/a"), new(int))
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Tombstone suppression at an intermediate scope level
+// ---------------------------------------------------------------------------.
+
+// TestMutableConfig_Layered_Delete_IntermediateScope_FallsBackToGlobal deletes
+// a key that was contributed at a group-level scope. The tombstone must be
+// resolved against the group scope prefix (not the global one), suppressing
+// only that level's contribution, so the global-scope value shines through.
+func TestMutableConfig_Layered_Delete_IntermediateScope_FallsBackToGlobal(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"}, // global scope.
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replication": map[string]any{"failover": "election"}, // group scope.
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file"))
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Baseline: group-scope value wins over global-scope value within the loader.
+	eff0, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var base string
+
+	_, err = eff0.Get(config.NewKeyPath("replication/failover"), &base)
+	require.NoError(t, err)
+	assert.Equal(t, "election", base)
+
+	// Delete the group-scoped contribution.
+	require.True(t, cfg.Delete(config.NewKeyPath("groups/storages/replication/failover")))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", failover,
+		"group-scope contribution suppressed; global-scope value must shine through")
+}
+
+// ---------------------------------------------------------------------------
+// MutableConfig.Merge / Update in layered mode
+// ---------------------------------------------------------------------------.
+
+func mergeSourceConfig(t *testing.T, data map[string]any) config.Config {
+	t.Helper()
+
+	b := config.NewBuilder()
+
+	b = b.AddCollector(collectors.NewMap(data))
+
+	cfg, errs := b.Build(t.Context())
+	require.Empty(t, errs)
+
+	return cfg
+}
+
+func TestMutableConfig_Layered_Merge_EffectiveReflectsModified(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	other := mergeSourceConfig(t, map[string]any{
+		"replication": map[string]any{"failover": "supervised"},
+	})
+	require.NoError(t, cfg.Merge(&other))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	m, err := eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", failover, "merged value must win over every loader")
+	assert.Equal(t, meta.ModifiedSourceName, m.Source.Name)
+}
+
+func TestMutableConfig_Layered_Update_EffectiveReflectsModified(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Update only touches keys that already exist in the root. The merged root
+	// already carries replication/failover from the env loader.
+	other := mergeSourceConfig(t, map[string]any{
+		"replication": map[string]any{"failover": "supervised"},
+	})
+	require.NoError(t, cfg.Update(&other))
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	m, err := eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "supervised", failover)
+	assert.Equal(t, meta.ModifiedSourceName, m.Source.Name)
+}
+
+// ---------------------------------------------------------------------------
+// Ancestor-scope deletion -> ErrPathNotFound (entityTombstoned prefix match)
+// ---------------------------------------------------------------------------.
+
+func TestMutableConfig_Layered_Delete_AncestorScope_ErrPathNotFound(t *testing.T) {
+	t.Parallel()
+
+	cfg := buildLayeredMutable(t)
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	_, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	// Delete a strict ancestor of the entity (the replicaset node).
+	require.True(t, cfg.Delete(config.NewKeyPath("groups/storages/replicasets/s-001")))
+
+	_, err = cfg.Effective(leafPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, config.ErrPathNotFound,
+		"deleting an ancestor scope must make the entity unresolvable, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// Delete validation failure (layered): no tombstone, state stays consistent
+// ---------------------------------------------------------------------------.
+
+func TestMutableConfig_Layered_Delete_ValidationFailure_NoTombstone(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+	// Root will carry exactly 3 top-level keys; any delete drops below the minimum.
+	builder = builder.WithValidator(&minKeysValidator{minKeys: 3})
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "manual"},
+		"alpha":       1,
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file"))
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.BuildMutable(t.Context())
+	require.Empty(t, errs)
+
+	leafPath := config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a")
+
+	// Deleting any top-level key would drop below the minimum and must be rejected.
+	require.False(t, cfg.Delete(config.NewKeyPath("alpha")))
+	require.False(t, cfg.Delete(config.NewKeyPath("replication/failover")))
+
+	// The rejected deletes left no tombstone behind and no state change:
+	// alpha is still resolvable and the entity still resolves.
+	var alpha int
+
+	_, err := cfg.Get(config.NewKeyPath("alpha"), &alpha)
+	require.NoError(t, err)
+	assert.Equal(t, 1, alpha)
+
+	eff, err := cfg.Effective(leafPath)
+	require.NoError(t, err)
+
+	var failover string
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "manual", failover)
+}
+
+// ---------------------------------------------------------------------------
+// WithNoInherit combined with multi-loader layering
+// ---------------------------------------------------------------------------.
+
+// TestLayered_NoInherit_MultiLoader verifies that WithNoInherit interacts
+// correctly with cross-loader layering: a non-leaf-scope contribution of a
+// no-inherit key is dropped even from a higher-priority loader, while a
+// leaf-scope contribution from a lower-priority loader is kept.
+func TestLayered_NoInherit_MultiLoader(t *testing.T) {
+	t.Parallel()
+
+	// Loader 1 (lower priority): leader set at the instance (leaf) scope.
+	loader1 := collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{"leader": "from-instance"},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	// Loader 2 (higher priority): leader set at the replicaset scope.
+	loader2 := collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{"leader": "from-replicaset"},
+				},
+			},
+		},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(loader1)
+	builder = builder.AddCollector(loader2)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithNoInherit("leader"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var leader string
+
+	_, err = eff.Get(config.NewKeyPath("leader"), &leader)
+	require.NoError(t, err)
+	assert.Equal(t, "from-instance", leader,
+		"non-leaf-scope no-inherit key from the higher-priority loader must be dropped; "+
+			"leaf-scope contribution from the lower-priority loader survives")
+}
+
+// ---------------------------------------------------------------------------
+// MultiCollector counts as a single layer
+// ---------------------------------------------------------------------------.
+
+// multiMapCollector wraps a base Map (so it satisfies config.Collector) and a
+// fixed list of sub-collectors, implementing config.MultiCollector.
+type multiMapCollector struct {
+	*collectors.Map
+
+	subs []config.Collector
+}
+
+func (m *multiMapCollector) Collectors(_ context.Context) ([]config.Collector, error) {
+	return m.subs, nil
+}
+
+// TestLayered_MultiCollector_CountsAsOneLayer verifies that a MultiCollector is
+// folded into one layer tree: a higher-priority top-level collector outranks the
+// whole MultiCollector regardless of which sub-collector or scope a value came from.
+func TestLayered_MultiCollector_CountsAsOneLayer(t *testing.T) {
+	t.Parallel()
+
+	sub1 := collectors.NewMap(map[string]any{
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{"mode": "from-sub1-instance"},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("sub1").WithSourceType(config.FileSource)
+
+	sub2 := collectors.NewMap(map[string]any{
+		"mode": "from-sub2-global",
+	}).WithName("sub2").WithSourceType(config.FileSource)
+
+	multi := &multiMapCollector{
+		Map:  collectors.NewMap(nil).WithName("multi").WithSourceType(config.FileSource),
+		subs: []config.Collector{sub1, sub2},
+	}
+
+	// Higher-priority top-level collector, global scope.
+	top := collectors.NewMap(map[string]any{
+		"mode": "from-top-global",
+	}).WithName("top").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(multi) // lower priority (one layer).
+	builder = builder.AddCollector(top)   // higher priority.
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var mode string
+
+	m, err := eff.Get(config.NewKeyPath("mode"), &mode)
+	require.NoError(t, err)
+	assert.Equal(t, "from-top-global", mode,
+		"higher-priority top-level collector must beat the whole MultiCollector layer")
+	assert.Equal(t, "top", m.Source.Name)
+}

--- a/merge.go
+++ b/merge.go
@@ -173,6 +173,40 @@ func copyAnnotation(root *tree.Node, path keypath.KeyPath, src Value) {
 	dest.SetAnnotation(anno)
 }
 
+// mergeTreeInto folds src into dst at the tree level.
+// Map-into-map is recursive; any other src child replaces the dst child
+// (carrying Source, Revision, Range, annotation, and isArray).
+// When src.OrderSet() and !dst.OrderSet() the dst children are reordered
+// to match src's key order and dst.OrderSet() is set true.
+func mergeTreeInto(dst, src *tree.Node) {
+	for _, key := range src.ChildrenKeys() {
+		srcChild := src.Child(key)
+		dstChild := dst.Child(key)
+
+		// Both sides are non-leaf maps → recurse.
+		if dstChild != nil && !dstChild.IsLeaf() && !srcChild.IsLeaf() {
+			// Carry ordering before recursing so children see the right dst state.
+			if srcChild.OrderSet() && !dstChild.OrderSet() {
+				_ = dstChild.ReorderChildren(srcChild.ChildrenKeys())
+				dstChild.SetOrderSet(true)
+			}
+
+			mergeTreeInto(dstChild, srcChild)
+
+			continue
+		}
+
+		// Otherwise replace: clone the entire src child subtree into dst.
+		dst.SetChild(key, cloneNode(srcChild))
+	}
+
+	// Apply ordering at this level.
+	if src.OrderSet() && !dst.OrderSet() {
+		_ = dst.ReorderChildren(src.ChildrenKeys())
+		dst.SetOrderSet(true)
+	}
+}
+
 // mergeMapIntoNode merges a map into a node's children recursively.
 func mergeMapIntoNode(node *tree.Node, m map[string]any, col Collector) {
 	// If node has a leaf value, clear it because we're merging a map into it.

--- a/merge_tree_test.go
+++ b/merge_tree_test.go
@@ -1,0 +1,220 @@
+package config //nolint:testpackage // exercises the unexported mergeTreeInto helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config/tree"
+)
+
+const (
+	srcFirst  = "first"
+	srcSecond = "second"
+)
+
+// TestMergeTreeInto_MapRecurse verifies that merging a src tree whose child is a map
+// recurses into the dst counterpart rather than replacing it.
+func TestMergeTreeInto_MapRecurse(t *testing.T) {
+	t.Parallel()
+
+	// dst: { server: { port: 8080, host: "localhost" } }
+	dst := tree.New()
+	server := tree.New()
+	port := tree.New()
+
+	port.Value = 8080
+	port.Source = srcFirst
+
+	host := tree.New()
+
+	host.Value = "localhost"
+	host.Source = srcFirst
+
+	server.SetChild("port", port)
+	server.SetChild("host", host)
+	dst.SetChild("server", server)
+
+	// src: { server: { port: 9090, ssl: true } }
+	src := tree.New()
+	srcServer := tree.New()
+	srcPort := tree.New()
+
+	srcPort.Value = 9090
+	srcPort.Source = srcSecond
+
+	srcSSL := tree.New()
+
+	srcSSL.Value = true
+	srcSSL.Source = srcSecond
+
+	srcServer.SetChild("port", srcPort)
+	srcServer.SetChild("ssl", srcSSL)
+	src.SetChild("server", srcServer)
+
+	mergeTreeInto(dst, src)
+
+	serverNode := dst.Child("server")
+	require.NotNil(t, serverNode)
+	// Three keys: port, host, ssl.
+	assert.Len(t, serverNode.ChildrenKeys(), 3)
+
+	portNode := serverNode.Child("port")
+	require.NotNil(t, portNode)
+	assert.Equal(t, 9090, portNode.Value)
+	assert.Equal(t, srcSecond, portNode.Source)
+
+	hostNode := serverNode.Child("host")
+	require.NotNil(t, hostNode)
+	assert.Equal(t, "localhost", hostNode.Value)
+	assert.Equal(t, srcFirst, hostNode.Source)
+
+	sslNode := serverNode.Child("ssl")
+	require.NotNil(t, sslNode)
+	assert.Equal(t, true, sslNode.Value)
+	assert.Equal(t, srcSecond, sslNode.Source)
+}
+
+// TestMergeTreeInto_LeafReplace verifies that a src leaf replaces a dst leaf.
+func TestMergeTreeInto_LeafReplace(t *testing.T) {
+	t.Parallel()
+
+	dst := tree.New()
+	dstLeaf := tree.New()
+
+	dstLeaf.Value = "old"
+	dstLeaf.Source = srcFirst
+	dstLeaf.Revision = "1"
+	dst.SetChild("key", dstLeaf)
+
+	src := tree.New()
+	srcLeaf := tree.New()
+
+	srcLeaf.Value = "new"
+	srcLeaf.Source = srcSecond
+	srcLeaf.Revision = "2"
+	src.SetChild("key", srcLeaf)
+
+	mergeTreeInto(dst, src)
+
+	keyNode := dst.Child("key")
+	require.NotNil(t, keyNode)
+	assert.Equal(t, "new", keyNode.Value)
+	assert.Equal(t, srcSecond, keyNode.Source)
+	assert.Equal(t, "2", keyNode.Revision)
+}
+
+// TestMergeTreeInto_ArrayCarry verifies that isArray is propagated from src to dst.
+func TestMergeTreeInto_ArrayCarry(t *testing.T) {
+	t.Parallel()
+
+	dst := tree.New()
+
+	src := tree.New()
+	srcArr := tree.New()
+	srcArr.MarkArray()
+
+	srcArr.Source = srcFirst
+
+	el0 := tree.New()
+
+	el0.Value = "a"
+	el0.Source = srcFirst
+	srcArr.SetChild("0", el0)
+	src.SetChild("roles", srcArr)
+
+	mergeTreeInto(dst, src)
+
+	rolesNode := dst.Child("roles")
+	require.NotNil(t, rolesNode)
+	assert.True(t, rolesNode.IsArray(), "isArray must be carried from src")
+	assert.Equal(t, srcFirst, rolesNode.Source)
+
+	el := rolesNode.Child("0")
+	require.NotNil(t, el)
+	assert.Equal(t, "a", el.Value)
+}
+
+// TestMergeTreeInto_OrderCarry verifies that when src.OrderSet() == true and
+// dst.OrderSet() == false, the dst children are reordered to match src and
+// dst.OrderSet() becomes true.
+func TestMergeTreeInto_OrderCarry(t *testing.T) {
+	t.Parallel()
+
+	// dst has keys inserted in order: c, a, b.
+	dst := tree.New()
+	dstMap := tree.New()
+	dstC := tree.New()
+
+	dstC.Value = "C"
+
+	dstA := tree.New()
+
+	dstA.Value = "A"
+
+	dstB := tree.New()
+
+	dstB.Value = "B"
+
+	dstMap.SetChild("c", dstC)
+	dstMap.SetChild("a", dstA)
+	dstMap.SetChild("b", dstB)
+	// dst order NOT set.
+	dst.SetChild("map", dstMap)
+
+	// src has the same keys but declares order: a, b, c and marks OrderSet.
+	src := tree.New()
+	srcMap := tree.New()
+	srcA := tree.New()
+
+	srcA.Value = "A2"
+	srcA.Source = srcSecond
+
+	srcB := tree.New()
+
+	srcB.Value = "B2"
+	srcB.Source = srcSecond
+
+	srcC := tree.New()
+
+	srcC.Value = "C2"
+	srcC.Source = srcSecond
+
+	srcMap.SetChild("a", srcA)
+	srcMap.SetChild("b", srcB)
+	srcMap.SetChild("c", srcC)
+	srcMap.SetOrderSet(true)
+	src.SetChild("map", srcMap)
+
+	mergeTreeInto(dst, src)
+
+	mapNode := dst.Child("map")
+	require.NotNil(t, mapNode)
+	assert.True(t, mapNode.OrderSet(), "dst should inherit OrderSet from src")
+
+	keys := mapNode.ChildrenKeys()
+	assert.Equal(t, []string{"a", "b", "c"}, keys, "keys should be reordered to src order")
+}
+
+// TestMergeTreeInto_AnnotationCarry verifies that annotation is cloned from src
+// children into dst.
+func TestMergeTreeInto_AnnotationCarry(t *testing.T) {
+	t.Parallel()
+
+	dst := tree.New()
+
+	src := tree.New()
+	srcLeaf := tree.New()
+
+	srcLeaf.Value = 42
+	srcLeaf.Source = srcFirst
+	srcLeaf.SetAnnotation("yaml-annotation")
+	src.SetChild("key", srcLeaf)
+
+	mergeTreeInto(dst, src)
+
+	keyNode := dst.Child("key")
+	require.NotNil(t, keyNode)
+	assert.Equal(t, "yaml-annotation", keyNode.Annotation())
+}


### PR DESCRIPTION
`Config.Effective` / `MutableConfig.Effective` / `EffectiveAll` resolved a leaf entity against the single merged tree, so scope depth always dominated loader priority — e.g. an env var routed to the global scope lost to a YAML value set per instance.

`Builder.Build` now keeps each top-level collector's contribution as its own layer tree, and effective resolution folds those layers in ascending-priority order: within a layer the deepest inheritance scope wins, across layers the higher-priority loader wins, and non-conflicting sub-keys from different loaders coexist. `MergeAppend`/`MergeDeep` keys compose across layers; a `MultiCollector` folds into a single layer.

`MutableConfig` mutations are mirrored into the layered view: `Set`/`Merge`/`Update` record values in a runtime overlay that outranks every loader, and `Delete` records a tombstone (and prunes the overlay) so the deleted contribution is suppressed from each layer's scope chain — re-setting a deleted path clears its tombstone. `Snapshot` deep-clones layers, overlay, and tombstones. Configs not produced by a `Builder` (slices, `Walk` snapshots, effective sub-configs) keep the original single-tree resolution.

Behavior change worth a minor-version bump; CHANGELOG updated. Covered by new tests in `config_test.go`, `inheritance_test.go`, `layered_extra_test.go`, and `merge_tree_test.go`; `golangci-lint run ./...` is clean.
