### PR TITLE
Fix MutableConfig mutation and YAML re-emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * `MutableConfig.Set` now preserves map and slice values as configuration
   subtrees, and `MutableConfig.Merge` keeps YAML sequences as sequences when
   merging them into a path that does not exist yet.
+* `MarshalYAML` now preserves the relative order of map-valued siblings, which
+  was previously lost when collectors flattened nested maps to leaf paths.
 
 ## [v1.3.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* `MutableConfig.Set` now preserves map and slice values as configuration
+  subtrees, and `MutableConfig.Merge` keeps YAML sequences as sequences when
+  merging them into a path that does not exist yet.
+
 ## [v1.3.0] - 2026-05-19
 
 This release changes how `Effective` resolves values — loader priority now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   was previously lost when collectors flattened nested maps to leaf paths.
 * Map-valued mutations via `MutableConfig.Set` now emit child keys in a
   deterministic, sorted order instead of Go's randomized map iteration order.
+* `MarshalYAML` now quotes unquoted source tokens that are strings under the
+  YAML 1.2 core schema but booleans/nulls under YAML 1.1 (`off`, `on`, `yes`,
+  `no`, ...), so re-emitted documents are not misread by YAML 1.1 loaders such
+  as libyaml.
 
 ## [v1.3.0] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   merging them into a path that does not exist yet.
 * `MarshalYAML` now preserves the relative order of map-valued siblings, which
   was previously lost when collectors flattened nested maps to leaf paths.
+* Map-valued mutations via `MutableConfig.Set` now emit child keys in a
+  deterministic, sorted order instead of Go's randomized map iteration order.
 
 ## [v1.3.0] - 2026-05-19
 

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"sync"
 
@@ -588,8 +589,15 @@ func mutableValueNode(value any) *tree.Node {
 			return node
 		}
 
-		for key, childValue := range typedValue {
-			node.SetChild(key, mutableValueNode(childValue))
+		keys := make([]string, 0, len(typedValue))
+		for key := range typedValue {
+			keys = append(keys, key)
+		}
+
+		slices.Sort(keys)
+
+		for _, key := range keys {
+			node.SetChild(key, mutableValueNode(typedValue[key]))
 		}
 	case []any:
 		node.MarkArray()

--- a/config.go
+++ b/config.go
@@ -551,6 +551,64 @@ func markModified(node *tree.Node) {
 	node.Revision = nextRevision(node.Revision)
 }
 
+// setMutableValue replaces composite mutation values with an equivalent node
+// subtree so maps and slices are not left as opaque leaves.
+func setMutableValue(root *tree.Node, path keypath.KeyPath, value any) *tree.Node {
+	switch value.(type) {
+	case map[string]any, []any:
+		replacement := mutableValueNode(value)
+		if len(path) == 0 {
+			return replacement
+		}
+
+		parentPath := path.Parent()
+		if len(parentPath) > 0 {
+			root.Set(parentPath, nil)
+		}
+
+		parent := root.Get(parentPath)
+		parent.SetChild(path.Leaf(), replacement)
+	default:
+		root.Set(path, value)
+	}
+
+	return root
+}
+
+// mutableValueNode builds the tree representation used by runtime composite
+// mutations. Empty composites keep their raw value so leaf reads still retain
+// the empty map or slice type.
+func mutableValueNode(value any) *tree.Node {
+	node := tree.New()
+
+	switch typedValue := value.(type) {
+	case map[string]any:
+		if len(typedValue) == 0 {
+			node.Value = typedValue
+			return node
+		}
+
+		for key, childValue := range typedValue {
+			node.SetChild(key, mutableValueNode(childValue))
+		}
+	case []any:
+		node.MarkArray()
+
+		if len(typedValue) == 0 {
+			node.Value = typedValue
+			return node
+		}
+
+		for i, childValue := range typedValue {
+			node.SetChild(strconv.Itoa(i), mutableValueNode(childValue))
+		}
+	default:
+		node.Value = value
+	}
+
+	return node
+}
+
 // Get retrieves a value at the specified path with read-lock protection.
 func (mc *MutableConfig) Get(path KeyPath, dest any) (MetaInfo, error) {
 	mc.mu.RLock()
@@ -638,7 +696,7 @@ func (mc *MutableConfig) Set(path KeyPath, value any) error {
 
 	oldRoot := cloneNode(mc.root)
 
-	mc.root.Set(path, value)
+	mc.root = setMutableValue(mc.root, path, value)
 
 	restoreErr := mc.validateOrRestore(oldRoot)
 	if restoreErr != nil {
@@ -652,7 +710,7 @@ func (mc *MutableConfig) Set(path KeyPath, value any) error {
 		mc.modified = tree.New()
 	}
 
-	mc.modified.Set(path, value)
+	mc.modified = setMutableValue(mc.modified, path, value)
 	markModified(mc.modified.Get(path))
 
 	return nil
@@ -660,8 +718,9 @@ func (mc *MutableConfig) Set(path KeyPath, value any) error {
 
 // mergeOp represents a pending merge operation.
 type mergeOp struct {
-	path  keypath.KeyPath
-	value any
+	path       keypath.KeyPath
+	value      any
+	arrayPaths []keypath.KeyPath
 }
 
 // materializeOps walks the other config and collects all leaf values as operations.
@@ -685,10 +744,62 @@ func materializeOps(other *Config) ([]mergeOp, error) {
 			return nil, fmt.Errorf("failed to get value at path %s: %w", path, err)
 		}
 
-		ops = append(ops, mergeOp{path: path, value: dest})
+		node := other.root.Get(path)
+		if node != nil && node.IsArray() {
+			dest = tree.ToAny(node)
+		}
+
+		ops = append(ops, mergeOp{
+			path:       path,
+			value:      dest,
+			arrayPaths: arrayPaths(other.root, path),
+		})
 	}
 
 	return ops, nil
+}
+
+// arrayPaths returns array nodes encountered from root through path. Merge
+// replays leaves into the target tree, so this preserves sequence metadata
+// when a replay creates an array path from scratch.
+func arrayPaths(root *tree.Node, path keypath.KeyPath) []keypath.KeyPath {
+	if root == nil {
+		return nil
+	}
+
+	node := root
+	current := keypath.KeyPath{}
+
+	var paths []keypath.KeyPath
+
+	if node.IsArray() {
+		paths = append(paths, current)
+	}
+
+	for _, segment := range path {
+		node = node.Child(segment)
+		if node == nil {
+			break
+		}
+
+		current = current.Append(segment)
+
+		if node.IsArray() {
+			paths = append(paths, current)
+		}
+	}
+
+	return paths
+}
+
+// markArrayPaths reapplies source sequence metadata after a leaf replay.
+func markArrayPaths(root *tree.Node, paths []keypath.KeyPath) {
+	for _, path := range paths {
+		node := root.Get(path)
+		if node != nil {
+			node.MarkArray()
+		}
+	}
 }
 
 // Merge merges two configurations so that all values from the new configuration
@@ -706,7 +817,8 @@ func (mc *MutableConfig) Merge(other *Config) error {
 	oldRoot := cloneNode(mc.root)
 
 	for _, mergeEntry := range ops {
-		mc.root.Set(mergeEntry.path, mergeEntry.value)
+		mc.root = setMutableValue(mc.root, mergeEntry.path, mergeEntry.value)
+		markArrayPaths(mc.root, mergeEntry.arrayPaths)
 	}
 
 	restoreErr := mc.validateOrRestore(oldRoot)
@@ -721,7 +833,9 @@ func (mc *MutableConfig) Merge(other *Config) error {
 
 	for _, mergeEntry := range ops {
 		markModified(mc.root.Get(mergeEntry.path))
-		mc.modified.Set(mergeEntry.path, mergeEntry.value)
+
+		mc.modified = setMutableValue(mc.modified, mergeEntry.path, mergeEntry.value)
+		markArrayPaths(mc.modified, mergeEntry.arrayPaths)
 		markModified(mc.modified.Get(mergeEntry.path))
 	}
 

--- a/defaultmerger.go
+++ b/defaultmerger.go
@@ -76,11 +76,12 @@ func (d *DefaultMerger) MergeValue(ctx MergerContext, root *tree.Node, keyPath k
 	col := ctx.Collector()
 	// Use internal mergeValue function.
 	mergeValue(root, keyPath, value, col)
-	// Record ordering if needed.
-	if col.KeepOrder() && len(keyPath) > 0 {
-		parent := keyPath.Parent()
-		child := keyPath.Leaf()
-		ctx.RecordOrdering(parent, child)
+	// Record every ancestor edge. Collectors flatten nested maps to leaves, so
+	// recording only the terminal key loses the relative order of map siblings.
+	if col.KeepOrder() {
+		for i := range keyPath {
+			ctx.RecordOrdering(keyPath[:i], keyPath[i])
+		}
 	}
 
 	return nil

--- a/marshal.go
+++ b/marshal.go
@@ -114,6 +114,7 @@ func scalarNodeToYAML(node *tree.Node) (*yaml.Node, error) {
 
 	if annotation.Val != nil && !mutated {
 		clone := cloneScalarYAMLNode(annotation.Val)
+		forcePlainStringQuoting(clone)
 
 		return clone, nil
 	}
@@ -140,6 +141,38 @@ func scalarNodeToYAML(node *tree.Node) (*yaml.Node, error) {
 	}
 
 	return out, nil
+}
+
+// forcePlainStringQuoting upgrades a plain (unquoted) string scalar to the
+// quoted style that go.yaml.in/yaml/v3 would itself choose when encoding the
+// same value from scratch.
+//
+// We need this only on the style-preserving path: when a source document
+// contained an unquoted token that is a string under the YAML 1.2 core schema
+// but a boolean or null under YAML 1.1 (off, on, yes, no, y, n, ~, ...), the
+// parser hands us a plain !!str scalar. Re-emitting it plain would let a YAML
+// 1.1 reader — notably Tarantool's libyaml-based config loader — interpret the
+// value as a bool/null instead of the string the rest of the pipeline already
+// treats it as. Quoting it makes the string interpretation explicit without
+// changing its value. yaml/v3's own encoder already quotes such values, so the
+// freshly-encoded (mutated) path is unaffected.
+func forcePlainStringQuoting(node *yaml.Node) {
+	if node.Kind != yaml.ScalarNode || node.Style != 0 {
+		return
+	}
+
+	if node.Tag != "" && node.Tag != yamlStringTag {
+		return
+	}
+
+	var probe yaml.Node
+	if probe.Encode(node.Value) != nil {
+		return
+	}
+
+	if probe.Style != 0 {
+		node.Style = probe.Style
+	}
 }
 
 // fillSpecialFloat fills out.Value/Tag for Inf and NaN values, which yaml.Node.Encode

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -27,6 +27,7 @@ func buildFromYAML(t *testing.T, data string) *config.MutableConfig {
 
 	builder := config.NewBuilder()
 
+	builder = builder.WithoutValidation()
 	builder = builder.AddCollector(col)
 
 	cfg, errs := builder.BuildMutable(t.Context())

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -106,6 +106,29 @@ mu: 3
 	assertKeyOrder(t, got, "", []string{"zeta", "alpha", "mu", "inserted"})
 }
 
+// TestMarshal_PreservesNestedMapOrder pins that ordered YAML map entries are
+// kept even when map-valued siblings are flattened into child leaves.
+func TestMarshal_PreservesNestedMapOrder(t *testing.T) {
+	t.Parallel()
+
+	input := `scope:
+    nested:
+        leaf: 1
+    scalar: 2
+    trailing:
+        leaf: 3
+`
+
+	cfg := buildFromYAML(t, input)
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	got := buildFromYAML(t, string(out))
+
+	assertKeyOrder(t, got, "scope", []string{"nested", "scalar", "trailing"})
+}
+
 // TestMarshal_PreservesComments pins that, after a Set on one leaf, head/line/foot
 // comments on neighboring nodes survive the marshal.
 func TestMarshal_PreservesComments(t *testing.T) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -193,6 +193,63 @@ literal: |
 	assert.Containsf(t, str, "literal: |", "literal block style lost:\n%s", str)
 }
 
+// TestMarshal_QuotesYAML11AmbiguousStrings pins that an unquoted source token
+// that is a string under YAML 1.2 but a bool/null under YAML 1.1 (off, on,
+// yes, ...) is re-emitted quoted, so a YAML 1.1 reader (e.g. Tarantool's
+// libyaml loader) does not reinterpret it as a bool/null. Genuinely plain
+// strings stay plain.
+func TestMarshal_QuotesYAML11AmbiguousStrings(t *testing.T) {
+	t.Parallel()
+
+	input := `failover: off
+toggle: on
+answer: yes
+denied: no
+host: localhost
+mode: manual
+count: 8080
+`
+
+	cfg := buildFromYAML(t, input)
+
+	out, err := cfg.MarshalYAML()
+	require.NoError(t, err)
+
+	str := string(out)
+
+	// Ambiguous tokens become quoted.
+	for _, want := range []string{
+		`failover: "off"`,
+		`toggle: "on"`,
+		`answer: "yes"`,
+		`denied: "no"`,
+	} {
+		assert.Containsf(t, str, want, "ambiguous token not quoted (want %q):\n%s", want, str)
+	}
+
+	// Genuine plain strings and non-string scalars are untouched.
+	assert.Regexpf(t, `(?m)^host: localhost$`, str, "plain string requoted:\n%s", str)
+	assert.Regexpf(t, `(?m)^mode: manual$`, str, "plain string requoted:\n%s", str)
+	assert.Regexpf(t, `(?m)^count: 8080$`, str, "integer requoted:\n%s", str)
+
+	// Values still round-trip as their original strings/ints.
+	got := buildFromYAML(t, str)
+
+	for path, want := range map[string]any{
+		"failover": "off",
+		"toggle":   "on",
+		"answer":   "yes",
+		"host":     "localhost",
+		"count":    int64(8080),
+	} {
+		var actual any
+
+		_, gerr := got.Get(config.NewKeyPath(path), &actual)
+		require.NoErrorf(t, gerr, "path %s missing after round-trip", path)
+		assert.Equalf(t, want, actual, "path %s", path)
+	}
+}
+
 func assertKeyOrder(t *testing.T, cfg *config.MutableConfig, path string, want []string) {
 	t.Helper()
 

--- a/mutable_mutation_test.go
+++ b/mutable_mutation_test.go
@@ -29,8 +29,8 @@ func TestMutableConfig_Set_YAMLRoundTrip(t *testing.T) {
 			name:  "map",
 			base:  "root:\n  existing: 1\n",
 			path:  config.NewKeyPath("root/added"),
-			value: map[string]any{"new": "val"},
-			want:  "root:\n  existing: 1\n  added:\n    new: val\n",
+			value: map[string]any{"zebra": "last", "alpha": "first"},
+			want:  "root:\n  existing: 1\n  added:\n    alpha: first\n    zebra: last\n",
 		},
 		{
 			name: "slice",

--- a/mutable_mutation_test.go
+++ b/mutable_mutation_test.go
@@ -1,0 +1,123 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config"
+)
+
+func TestMutableConfig_Set_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		base  string
+		path  config.KeyPath
+		value any
+		want  string
+	}{
+		{
+			name:  "scalar",
+			base:  "root:\n  value: old\n",
+			path:  config.NewKeyPath("root/value"),
+			value: "new",
+			want:  "root:\n  value: new\n",
+		},
+		{
+			name:  "map",
+			base:  "root:\n  existing: 1\n",
+			path:  config.NewKeyPath("root/added"),
+			value: map[string]any{"new": "val"},
+			want:  "root:\n  existing: 1\n  added:\n    new: val\n",
+		},
+		{
+			name: "slice",
+			base: "root:\n  existing: 1\n",
+			path: config.NewKeyPath("root/listen"),
+			value: []any{
+				map[string]any{"uri": "127.0.0.1:3303"},
+			},
+			want: "root:\n  existing: 1\n  listen:\n    - uri: 127.0.0.1:3303\n",
+		},
+		{
+			name:  "overwrite existing subtree",
+			base:  "a:\n  b:\n    - x: 1\n",
+			path:  config.NewKeyPath("a/b"),
+			value: map[string]any{"new": "val"},
+			want:  "a:\n  b:\n    new: val\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := buildFromYAML(t, tt.base)
+
+			require.NoError(t, cfg.Set(tt.path, tt.value))
+			requireMutableYAMLRoundTrip(t, cfg, tt.want)
+		})
+	}
+}
+
+func TestMutableConfig_Merge_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		base  string
+		other string
+		want  string
+	}{
+		{
+			name:  "existing list",
+			base:  "root:\n  added:\n    listen:\n      - uri: old\n",
+			other: "root:\n  added:\n    listen:\n      - uri: 127.0.0.1:3303\n",
+			want:  "root:\n  added:\n    listen:\n      - uri: 127.0.0.1:3303\n",
+		},
+		{
+			name:  "fresh list",
+			base:  "root:\n  existing: 1\n",
+			other: "root:\n  added:\n    listen:\n      - uri: 127.0.0.1:3303\n",
+			want:  "root:\n  existing: 1\n  added:\n    listen:\n      - uri: 127.0.0.1:3303\n",
+		},
+		{
+			name: "nested map and list",
+			base: "root:\n  existing: 1\n",
+			other: "root:\n  added:\n    groups:\n      storage:\n        listen:\n" +
+				"          - uri: 127.0.0.1:3303\n",
+			want: "root:\n  existing: 1\n  added:\n    groups:\n      storage:\n        listen:\n" +
+				"          - uri: 127.0.0.1:3303\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := buildFromYAML(t, tt.base)
+			other := buildFromYAML(t, tt.other)
+			otherSnapshot := other.Snapshot()
+
+			require.NoError(t, cfg.Merge(&otherSnapshot))
+			requireMutableYAMLRoundTrip(t, cfg, tt.want)
+		})
+	}
+}
+
+func requireMutableYAMLRoundTrip(t *testing.T, cfg *config.MutableConfig, want string) {
+	t.Helper()
+
+	snapshot := cfg.Snapshot()
+	out, err := snapshot.MarshalYAML()
+	require.NoError(t, err)
+	require.Equal(t, want, string(out))
+
+	roundTripped := buildFromYAML(t, string(out))
+	roundTripSnapshot := roundTripped.Snapshot()
+	roundTripOut, err := roundTripSnapshot.MarshalYAML()
+	require.NoError(t, err)
+	require.Equal(t, want, string(roundTripOut))
+}


### PR DESCRIPTION
Four fixes to `MutableConfig` mutation and YAML marshalling, surfaced while migrating `tt`'s cluster config to `goconfig.MutableConfig`.

- **Preserve composite values** — `Set` keeps map/slice values as subtrees; `Merge` keeps YAML sequences as sequences for not-yet-existing paths.
- **Record all ancestor edges** — `MarshalYAML` preserves the relative order of map-valued siblings (previously lost when collectors flatten nested maps to leaves).
- **Sort map keys** — map-valued `Set` now emits child keys in deterministic, sorted order instead of Go's randomized map iteration order.
- **Quote YAML 1.1 ambiguous tokens** — unquoted source tokens that are strings under YAML 1.2 but bool/null under YAML 1.1 (`off`, `on`, `yes`, `no`, ...) are re-emitted quoted, so YAML 1.1 loaders (e.g. libyaml) don't misread them.
