### PR TITLE
config: deep-merge maps by default during scope-chain inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+* The default inheritance merge strategy is now `MergeDeep` (was
+  `MergeReplace`). A higher-priority scope or layer that sets only one
+  sub-key of a map no longer drops sibling sub-keys contributed by a
+  lower-priority scope or layer, aligning single-loader scope-chain
+  resolution with the cross-loader invariant documented on
+  `accumulateLayerResult`. Explicit `WithInheritMerge(key, MergeReplace)`
+  still means wholesale replace.
+* `WithNoInheritFrom` (and `WithNoInherit`) prefix exclusions are now
+  enforced at every depth of a scope's subtree, not just on the layer's
+  top-level keys. Nested-path exclusions like
+  `WithNoInheritFrom(Global, "credentials/users")` now actually fire under
+  the new default deep merge.
+
 ### Fixed
 
 * `MutableConfig.Set` now preserves map and slice values as configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* Explicit `WithInheritMerge(key, MergeReplace)` now wholesale-replaces map
+  values consistently in both single-loader scope-chain resolution and
+  cross-loader accumulation. Previously `accumulateLayerResult` silently
+  recursed into map nodes for `MergeReplace`, contradicting the constant's
+  docstring and producing different effective views for the same explicit
+  user opt-in depending on whether the conflict came from two scopes or two
+  loaders.
+* `mergeNodeValue` (collector-side merge) now uses `isMapNode` to detect
+  maps instead of `!IsLeaf`, so an array node followed by a map value no
+  longer becomes a hybrid node carrying both the array flag and
+  string-keyed children. Replacements (scalar, slice, or a map overwriting
+  an array) also drop the `isArray` flag.
 * Default deep-merge no longer index-merges arrays nested inside merged
   maps. A higher-priority `iproto/listen: [a, b]` nested under a deep-merged
   `iproto` now fully replaces a lower-priority `iproto/listen: [x, y, z]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* Default deep-merge no longer index-merges arrays nested inside merged
+  maps. A higher-priority `iproto/listen: [a, b]` nested under a deep-merged
+  `iproto` now fully replaces a lower-priority `iproto/listen: [x, y, z]`
+  instead of leaking the orphan `z` into the effective view. Both
+  `deepMergeNodes` (inheritance) and `mergeTreeInto` (cross-loader) gate on
+  `isMapNode` instead of `!IsLeaf` so arrays stay opaque.
 * `MutableConfig.Set` now preserves map and slice values as configuration
   subtrees, and `MutableConfig.Merge` keeps YAML sequences as sequences when
   merging them into a path that does not exist yet.

--- a/inheritance.go
+++ b/inheritance.go
@@ -704,7 +704,12 @@ func mergeArrayNodes(existing, source *tree.Node) {
 }
 
 // deepMergeNodes recursively merges source children into dst.
-// Source keys override dst keys for leaves; recurse for nested maps.
+// Source keys override dst keys for leaves and for arrays; recurse only
+// for nested maps. Arrays are opaque on purpose — index-merging a
+// higher-priority [a, b] with a lower-priority [x, y, z] would leak z
+// into the effective view, which surprised real Tarantool cluster
+// configs where iproto.listen at the instance scope is expected to fully
+// replace iproto.listen at the global scope.
 func deepMergeNodes(dst, source *tree.Node) {
 	for _, key := range source.ChildrenKeys() {
 		srcChild := source.Child(key)
@@ -715,8 +720,8 @@ func deepMergeNodes(dst, source *tree.Node) {
 			continue
 		}
 
-		// Both non-leaf: recurse.
-		if !dstChild.IsLeaf() && !srcChild.IsLeaf() {
+		// Both sides must be maps (not leaves, not arrays) to recurse.
+		if isMapNode(dstChild) && isMapNode(srcChild) {
 			deepMergeNodes(dstChild, srcChild)
 			continue
 		}

--- a/inheritance.go
+++ b/inheritance.go
@@ -450,26 +450,14 @@ func resolveEffective(layers []*tree.Node, inheritanceCfg *inheritanceConfig) *t
 }
 
 // accumulateLayerResult folds the higher-priority layer srcLayer into dst.
-// MergeAppend/MergeDeep keys use their configured strategy. MergeReplace keys
-// replace the dst value, except that two map nodes are merged recursively so a
-// loader that sets only one sub-key does not drop sibling sub-keys contributed
-// by a lower-priority loader.
+// Each key uses its configured strategy — including the implicit default,
+// which is now MergeDeep and handles the cross-loader sibling-sub-key
+// invariant uniformly. Explicit MergeReplace means wholesale replace here
+// just as it does inside a single layer's scope chain.
 func accumulateLayerResult(dst, srcLayer *tree.Node, inheritanceCfg *inheritanceConfig) {
 	for _, key := range srcLayer.ChildrenKeys() {
 		src := srcLayer.Child(key)
-		strategy, _ := inheritanceCfg.strategyFor(key)
-
-		switch strategy {
-		case MergeAppend, MergeDeep:
-			mergeIntoResultWithStrategies(dst, key, src, inheritanceCfg)
-
-		case MergeReplace:
-			if dstChild := dst.Child(key); isMapNode(dstChild) && isMapNode(src) {
-				mergeTreeInto(dstChild, src)
-			} else {
-				dst.SetChild(key, cloneNode(src))
-			}
-		}
+		mergeIntoResultWithStrategies(dst, key, src, inheritanceCfg)
 	}
 }
 

--- a/inheritance.go
+++ b/inheritance.go
@@ -18,8 +18,10 @@ const segmentsPerLevel = 2
 type InheritMergeStrategy int
 
 const (
-	// MergeReplace replaces the value from the parent with the child's value.
-	// This is the default strategy for all keys.
+	// MergeReplace replaces the value from the parent with the child's value
+	// wholesale, even for map nodes. Use this when you explicitly want a
+	// higher-priority scope's map to drop sibling sub-keys contributed by a
+	// lower-priority scope. Opt-in only; the default strategy is MergeDeep.
 	MergeReplace InheritMergeStrategy = iota
 	// MergeAppend appends child slice elements to the parent's slice.
 	// If the value is not a slice, behaves like MergeReplace.
@@ -27,6 +29,7 @@ const (
 	// MergeDeep recursively merges maps from parent and child.
 	// Child keys override parent keys; parent-only keys are preserved.
 	// If the value is not a map, behaves like MergeReplace.
+	// This is the default strategy for all keys.
 	MergeDeep
 )
 
@@ -116,11 +119,12 @@ func WithNoInherit(keys ...string) InheritanceOption {
 //
 // Example:
 //
-//	WithNoInheritFrom(config.Global, "snapshot.dir")
+//	WithNoInheritFrom(config.Global, "snapshot/dir")
 //
-// means snapshot.dir set at the global level does not flow into
-// group/replicaset/instance levels. But snapshot.dir set at the group
-// level DOES flow into replicaset/instance levels.
+// means snapshot/dir set at the global level does not flow into
+// group/replicaset/instance levels. But snapshot/dir set at the group
+// level DOES flow into replicaset/instance levels. Keys are split on "/" —
+// dot-separated segments are treated as literal single-segment names.
 func WithNoInheritFrom(level string, keys ...string) InheritanceOption {
 	return func(inheritanceCfg *inheritanceConfig) {
 		// Find level index.
@@ -312,7 +316,12 @@ func (inheritanceCfg *inheritanceConfig) shouldInherit(levelIdx int, key keypath
 
 // strategyFor returns the merge strategy for a key and whether it was
 // explicitly registered. When explicit is false, the returned strategy
-// is the default (MergeReplace).
+// is the default (MergeDeep): scopes of a single loader, and layers across
+// loaders, recursively merge map nodes — so a higher-priority scope/layer
+// that sets only one sub-key does not drop sibling sub-keys contributed by
+// a lower-priority one. Leaves still follow higher-priority-wins. Users who
+// want a top-level map to be replaced wholesale must opt in explicitly via
+// WithInheritMerge(key, MergeReplace).
 func (inheritanceCfg *inheritanceConfig) strategyFor(key string) (InheritMergeStrategy, bool) {
 	if inheritanceCfg.mergeStrategies != nil {
 		if strategy, ok := inheritanceCfg.mergeStrategies[key]; ok {
@@ -320,7 +329,7 @@ func (inheritanceCfg *inheritanceConfig) strategyFor(key string) (InheritMergeSt
 		}
 	}
 
-	return MergeReplace, false
+	return MergeDeep, false
 }
 
 // hasSubStrategies checks if any merge strategy is registered for a sub-path
@@ -351,33 +360,42 @@ func foldScopeChainInto(
 	inheritanceCfg *inheritanceConfig,
 	suppressedByLevel map[int][]keypath.KeyPath,
 ) {
+	leafIdx := len(scopeChain) - 1
+
 	for levelIdx, layer := range scopeChain {
 		if layer == nil {
 			continue
 		}
 
-		// Apply per-level pruning (tombstone suppression) if requested.
+		// Collect prefixes to prune from this layer before folding:
+		//   - tombstones (suppressedByLevel) at every level,
+		//   - WithNoInherit / WithNoInheritFrom exclusions at non-leaf
+		//     levels — the leaf scope always carries its own values.
+		// Pruning (rather than shallow per-iteration filtering) is what makes
+		// nested-path exclusions like WithNoInheritFrom(Global, "a/b/c") fire
+		// once the default merge recurses into sub-trees.
+		var prunes []keypath.KeyPath
+
 		if len(suppressedByLevel[levelIdx]) > 0 {
+			prunes = append(prunes, suppressedByLevel[levelIdx]...)
+		}
+
+		if levelIdx < leafIdx {
+			prunes = append(prunes, inheritanceCfg.noInherit...)
+			prunes = append(prunes, inheritanceCfg.noInheritFrom[levelIdx]...)
+		}
+
+		if len(prunes) > 0 {
 			layer = cloneNode(layer)
-			for _, kp := range suppressedByLevel[levelIdx] {
+			for _, kp := range prunes {
 				pruneTreePath(layer, kp)
 			}
 		}
 
 		for _, key := range layer.ChildrenKeys() {
-			keyPath := keypath.NewKeyPath(key)
-
 			// Skip structural keys (groups, replicasets, instances, …).
 			if isStructuralKey(inheritanceCfg, key) {
 				continue
-			}
-
-			// Apply exclusion rules.
-			if !inheritanceCfg.shouldInherit(levelIdx, keyPath) {
-				// Only include at the LEAF level (last entry in the chain).
-				if levelIdx < len(scopeChain)-1 {
-					continue
-				}
 			}
 
 			child := layer.Child(key)

--- a/inheritance_internal_test.go
+++ b/inheritance_internal_test.go
@@ -412,6 +412,142 @@ func TestMergeIntoResult_EdgeCases(t *testing.T) {
 	})
 }
 
+// TestDeepMergeNodes_ArraysAreOpaque verifies the unit-level invariant
+// that deepMergeNodes never recurses into a child when either side is an
+// array node — arrays are replaced wholesale, never index-merged. This is
+// the function-boundary safety net for the bug fixed by the array-opaque
+// commit: previously the recursion check used !IsLeaf, which let it walk
+// into array nodes' indexed children and produce hybrid arrays.
+func TestDeepMergeNodes_ArraysAreOpaque(t *testing.T) {
+	t.Parallel()
+
+	// arrayNode builds an array node with the given child leaf values,
+	// keyed by index ("0", "1", ...) and tagged with MarkArray so IsArray
+	// returns true.
+	arrayNode := func(values ...any) *tree.Node {
+		node := tree.New()
+		for i, v := range values {
+			child := tree.New()
+
+			child.Value = v
+
+			node.SetChild(strconv.Itoa(i), child)
+		}
+
+		node.MarkArray()
+
+		return node
+	}
+
+	t.Run("BothArrays_NestedInMap_HigherShorter", func(t *testing.T) {
+		t.Parallel()
+
+		dst := tree.New()
+		dst.SetChild("listen", arrayNode("a", "b", "c"))
+
+		src := tree.New()
+		src.SetChild("listen", arrayNode("x"))
+
+		deepMergeNodes(dst, src)
+
+		listen := dst.Child("listen")
+		require.NotNil(t, listen)
+		assert.True(t, listen.IsArray())
+		assert.Equal(t, []string{"0"}, listen.ChildrenKeys(),
+			"src array must replace dst array wholesale — no leaked dst[1], dst[2]")
+		assert.Equal(t, "x", listen.Child("0").Value)
+	})
+
+	t.Run("BothArrays_NestedInMap_HigherLonger", func(t *testing.T) {
+		t.Parallel()
+
+		dst := tree.New()
+		dst.SetChild("listen", arrayNode("a"))
+
+		src := tree.New()
+		src.SetChild("listen", arrayNode("x", "y", "z"))
+
+		deepMergeNodes(dst, src)
+
+		listen := dst.Child("listen")
+		require.NotNil(t, listen)
+		assert.True(t, listen.IsArray())
+		assert.Equal(t, []string{"0", "1", "2"}, listen.ChildrenKeys())
+		assert.Equal(t, "x", listen.Child("0").Value)
+		assert.Equal(t, "y", listen.Child("1").Value)
+		assert.Equal(t, "z", listen.Child("2").Value)
+	})
+
+	t.Run("DstArraySrcMap_AtSameKey_SrcWins", func(t *testing.T) {
+		t.Parallel()
+
+		dst := tree.New()
+		dst.SetChild("k", arrayNode("a", "b"))
+
+		srcChild := tree.New()
+		leaf := tree.New()
+
+		leaf.Value = "v"
+		srcChild.SetChild("nested", leaf)
+
+		src := tree.New()
+		src.SetChild("k", srcChild)
+
+		deepMergeNodes(dst, src)
+
+		got := dst.Child("k")
+		require.NotNil(t, got)
+		assert.False(t, got.IsArray(), "dst array must be replaced by src map")
+		assert.Equal(t, "v", got.Child("nested").Value)
+	})
+
+	t.Run("DstMapSrcArray_AtSameKey_SrcWins", func(t *testing.T) {
+		t.Parallel()
+
+		dstChild := tree.New()
+		leaf := tree.New()
+
+		leaf.Value = "v"
+		dstChild.SetChild("nested", leaf)
+
+		dst := tree.New()
+		dst.SetChild("k", dstChild)
+
+		src := tree.New()
+		src.SetChild("k", arrayNode("x", "y"))
+
+		deepMergeNodes(dst, src)
+
+		got := dst.Child("k")
+		require.NotNil(t, got)
+		assert.True(t, got.IsArray(), "dst map must be replaced by src array")
+		assert.Nil(t, got.Child("nested"),
+			"map sub-key must be gone after array replace")
+	})
+
+	t.Run("DstArraySrcLeaf_AtSameKey_SrcWins", func(t *testing.T) {
+		t.Parallel()
+
+		dst := tree.New()
+		dst.SetChild("k", arrayNode("a", "b", "c"))
+
+		srcLeaf := tree.New()
+
+		srcLeaf.Value = "scalar"
+
+		src := tree.New()
+		src.SetChild("k", srcLeaf)
+
+		deepMergeNodes(dst, src)
+
+		got := dst.Child("k")
+		require.NotNil(t, got)
+		assert.False(t, got.IsArray())
+		assert.True(t, got.IsLeaf())
+		assert.Equal(t, "scalar", got.Value)
+	})
+}
+
 func TestWalkNodes_CtxCancelled(t *testing.T) {
 	t.Parallel()
 	// Create a leaf node.

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -97,6 +97,558 @@ func TestWithInheritance_BasicInheritance(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:3301", listen[0]["uri"])
 }
 
+// TestWithInheritance_CrossScope_DeeplyNestedMapMerge verifies that the
+// default deep-merge recurses arbitrarily deep into map structures: a
+// global a/b/c/d/e/{x:1} and an instance a/b/c/d/e/{y:2} both survive
+// end-to-end. The previous wholesale-replace default would have lost x.
+func TestWithInheritance_CrossScope_DeeplyNestedMapMerge(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{
+				"c": map[string]any{
+					"d": map[string]any{
+						"e": map[string]any{"x": 1},
+					},
+				},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"a": map[string]any{
+									"b": map[string]any{
+										"c": map[string]any{
+											"d": map[string]any{
+												"e": map[string]any{"y": 2},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var valX, valY int
+
+	_, err = eff.Get(config.NewKeyPath("a/b/c/d/e/x"), &valX)
+	require.NoError(t, err, "deeply nested lower-priority sub-key must survive")
+	assert.Equal(t, 1, valX)
+
+	_, err = eff.Get(config.NewKeyPath("a/b/c/d/e/y"), &valY)
+	require.NoError(t, err, "deeply nested higher-priority sub-key must be present")
+	assert.Equal(t, 2, valY)
+}
+
+// TestWithInheritance_CrossScope_FourLevelMapMerge verifies that every
+// scope in the Global → group → replicaset → instance chain can contribute
+// a disjoint leaf to the same nested map and all four survive the merge.
+// This is the scope-chain version of the existing TestLayered_CrossLoader_
+// non-conflicting test, extended to the maximum hierarchy depth.
+func TestWithInheritance_CrossScope_FourLevelMapMerge(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"failover": "election"}, // global.
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replication": map[string]any{"timeout": 30}, // group.
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"replication": map[string]any{"bootstrap_strategy": "auto"}, // replicaset.
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"replication": map[string]any{"connect_timeout": 5}, // instance.
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var failover, bootstrap string
+
+	var timeout, connect int
+
+	_, err = eff.Get(config.NewKeyPath("replication/failover"), &failover)
+	require.NoError(t, err)
+	assert.Equal(t, "election", failover, "global contribution must survive")
+
+	_, err = eff.Get(config.NewKeyPath("replication/timeout"), &timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 30, timeout, "group contribution must survive")
+
+	_, err = eff.Get(config.NewKeyPath("replication/bootstrap_strategy"), &bootstrap)
+	require.NoError(t, err)
+	assert.Equal(t, "auto", bootstrap, "replicaset contribution must survive")
+
+	_, err = eff.Get(config.NewKeyPath("replication/connect_timeout"), &connect)
+	require.NoError(t, err)
+	assert.Equal(t, 5, connect, "instance contribution must survive")
+}
+
+// TestWithInheritance_CrossScope_MultiLevelConflictPriority verifies that
+// when multiple scopes set the same leaf path, the highest-priority scope
+// that sets it wins — not just the leaf scope (the instance may not
+// override it). With a global=1, group=2, replicaset=3, instance-unset
+// chain, the effective value must be 3.
+func TestWithInheritance_CrossScope_MultiLevelConflictPriority(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"replication": map[string]any{"timeout": 1}, // global.
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replication": map[string]any{"timeout": 2}, // group.
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"replication": map[string]any{"timeout": 3}, // replicaset.
+						"instances": map[string]any{
+							"s-001-a": map[string]any{}, // instance has no replication.
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var timeout int
+
+	_, err = eff.Get(config.NewKeyPath("replication/timeout"), &timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 3, timeout, "highest-priority defined scope must win")
+}
+
+// TestWithInheritance_CrossScope_DefaultMatchesExplicitMergeDeep is a
+// sanity check that the new default strategy is wired exactly to
+// MergeDeep. Two builders with the same input — one relying on the default,
+// one declaring WithInheritMerge("iproto", MergeDeep) — must produce
+// identical effective views.
+func TestWithInheritance_CrossScope_DefaultMatchesExplicitMergeDeep(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{"peer": map[string]any{"login": "replicator"}},
+			"listen":    map[string]any{"params": map[string]any{"transport": "plain"}},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"listen": map[string]any{"uri": "127.0.0.1:3301"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	build := func(explicit bool) config.Config {
+		t.Helper()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(
+			collectors.NewMap(data).WithName("test").WithSourceType(config.FileSource),
+		)
+		if explicit {
+			builder = builder.WithInheritance(
+				config.Levels(config.Global, "groups", "replicasets", "instances"),
+				config.WithInheritMerge("iproto", config.MergeDeep),
+			)
+		} else {
+			builder = builder.WithInheritance(
+				config.Levels(config.Global, "groups", "replicasets", "instances"),
+			)
+		}
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		return cfg
+	}
+
+	for _, label := range []string{"default", "explicit"} {
+		cfg := build(label == "explicit")
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err, label)
+
+		var login string
+
+		_, err = eff.Get(config.NewKeyPath("iproto/advertise/peer/login"), &login)
+		require.NoError(t, err, label)
+		assert.Equal(t, "replicator", login, label)
+
+		var transport string
+
+		_, err = eff.Get(config.NewKeyPath("iproto/listen/params/transport"), &transport)
+		require.NoError(t, err, label)
+		assert.Equal(t, "plain", transport, label)
+
+		var uri string
+
+		_, err = eff.Get(config.NewKeyPath("iproto/listen/uri"), &uri)
+		require.NoError(t, err, label)
+		assert.Equal(t, "127.0.0.1:3301", uri, label)
+	}
+}
+
+// TestWithInheritance_NoInheritFrom_DeepPathPruning extends the prefix-
+// matching test with several deeper-path variants now that exclusions are
+// enforced at every depth (not just top-level iteration keys). Each
+// sub-case configures a different excluded prefix and verifies that the
+// pruned path is gone while siblings survive.
+func TestWithInheritance_NoInheritFrom_DeepPathPruning(t *testing.T) {
+	t.Parallel()
+
+	mkCfg := func(t *testing.T, excluded string) config.Config {
+		t.Helper()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"credentials": map[string]any{
+				"users": map[string]any{
+					"admin": map[string]any{
+						"password": "global-admin-pass",
+						"roles":    []any{"super"},
+					},
+					"monitor": map[string]any{
+						"password": "global-monitor-pass",
+					},
+				},
+				"settings": map[string]any{
+					"timeout": 30,
+				},
+			},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test").WithSourceType(config.FileSource))
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+			config.WithNoInheritFrom(config.Global, excluded),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		return cfg
+	}
+
+	t.Run("ExcludeSpecificUser", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := mkCfg(t, "credentials/users/admin")
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		// admin pruned away.
+		_, err = eff.Get(config.NewKeyPath("credentials/users/admin/password"), new(string))
+		require.Error(t, err, "excluded sub-tree must be pruned")
+
+		// monitor (sibling under credentials/users) and settings (sibling
+		// under credentials) survive.
+		var monitorPass string
+
+		_, err = eff.Get(config.NewKeyPath("credentials/users/monitor/password"), &monitorPass)
+		require.NoError(t, err)
+		assert.Equal(t, "global-monitor-pass", monitorPass)
+
+		var timeout int
+
+		_, err = eff.Get(config.NewKeyPath("credentials/settings/timeout"), &timeout)
+		require.NoError(t, err)
+		assert.Equal(t, 30, timeout)
+	})
+
+	t.Run("ExcludeLeafFieldOnly", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := mkCfg(t, "credentials/users/admin/roles")
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		// roles pruned, password survives (same admin map).
+		_, err = eff.Get(config.NewKeyPath("credentials/users/admin/roles"), new([]string))
+		require.Error(t, err)
+
+		var pass string
+
+		_, err = eff.Get(config.NewKeyPath("credentials/users/admin/password"), &pass)
+		require.NoError(t, err)
+		assert.Equal(t, "global-admin-pass", pass)
+	})
+
+	t.Run("ExcludeWholeTopLevelKey", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := mkCfg(t, "credentials")
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		// Entire credentials subtree from global is pruned.
+		_, err = eff.Get(config.NewKeyPath("credentials/users/admin/password"), new(string))
+		require.Error(t, err)
+
+		_, err = eff.Get(config.NewKeyPath("credentials/settings/timeout"), new(int))
+		require.Error(t, err)
+	})
+}
+
+// TestWithInheritance_CrossScope_DeepNoInheritStillFires verifies that
+// WithNoInherit (universal exclusion) also applies at every depth via the
+// new pruning path — not just on top-level layer iteration. The excluded
+// sub-tree must vanish from every non-leaf scope while the leaf (instance)
+// can still set the same path for itself.
+func TestWithInheritance_CrossScope_DeepNoInheritStillFires(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer": map[string]any{"login": "global-login"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"iproto": map[string]any{
+					"advertise": map[string]any{
+						"peer": map[string]any{"login": "group-login"},
+					},
+				},
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"advertise": map[string]any{
+										"peer": map[string]any{"login": "instance-login"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithNoInherit("iproto/advertise/peer"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// Instance's own value (leaf scope) is preserved per the leaf-scope
+	// carve-out.
+	var login string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/advertise/peer/login"), &login)
+	require.NoError(t, err)
+	assert.Equal(t, "instance-login", login)
+}
+
+// TestWithInheritance_CrossScope_NonConflictingSubkeysCoexist is the
+// scope-chain analogue of TestLayered_CrossLoader_NonConflictingSubkeysCoexist:
+// when a single loader sets disjoint sub-keys of the same top-level map at
+// different scopes (e.g. instance sets iproto/listen while global sets
+// iproto/advertise/peer/login), both must survive in the effective view. The
+// higher-priority scope's bare presence of "iproto" must not wipe out the
+// lower-priority scope's sibling sub-keys.
+func TestWithInheritance_CrossScope_NonConflictingSubkeysCoexist(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer": map[string]any{"login": "replicator"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"listen": []any{
+										map[string]any{"uri": "127.0.0.1:3301"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	instanceCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var login string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("iproto/advertise/peer/login"), &login)
+	require.NoError(t, err, "lower-priority scope sub-key must survive")
+	assert.Equal(t, "replicator", login)
+
+	var listen []map[string]string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err, "higher-priority scope sub-key must be present")
+	require.Len(t, listen, 1)
+	assert.Equal(t, "127.0.0.1:3301", listen[0]["uri"])
+}
+
+// TestWithInheritance_CrossScope_ConflictingLeafHigherPriorityWins is the
+// scope-chain analogue of
+// TestLayered_CrossLoader_ConflictingSubkeyHigherPriorityWins: when both a
+// parent and a child scope set the same leaf, the child scope wins, while
+// non-conflicting sibling sub-keys from the parent scope still coexist in
+// the effective view.
+func TestWithInheritance_CrossScope_ConflictingLeafHigherPriorityWins(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer":     map[string]any{"login": "replicator"},
+				"sharding": map[string]any{"login": "storage"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"advertise": map[string]any{
+										"peer": map[string]any{"login": "replicator-instance"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	instanceCfg, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var peerLogin string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("iproto/advertise/peer/login"), &peerLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "replicator-instance", peerLogin, "instance scope wins on conflict")
+
+	var shardingLogin string
+
+	_, err = instanceCfg.Get(config.NewKeyPath("iproto/advertise/sharding/login"), &shardingLogin)
+	require.NoError(t, err, "non-conflicting sibling from global scope must survive")
+	assert.Equal(t, "storage", shardingLogin)
+}
+
 func TestWithInheritance_ChildOverridesParent(t *testing.T) {
 	t.Parallel()
 
@@ -934,10 +1486,13 @@ func TestWithInheritance_NoInheritFrom_PrefixMatching(t *testing.T) {
 		},
 	}).WithName("test").WithSourceType(config.FileSource))
 
-	// Exclude credentials.users at global level (prefix matching).
+	// Exclude credentials/users at global level (prefix matching). Keys are
+	// "/"-separated; the previous "credentials.users" form silently matched
+	// nothing and only "worked" because the default merge strategy used to
+	// wholesale-replace credentials at the group scope.
 	builder = builder.WithInheritance(
 		config.Levels(config.Global, "groups", "replicasets", "instances"),
-		config.WithNoInheritFrom(config.Global, "credentials.users"),
+		config.WithNoInheritFrom(config.Global, "credentials/users"),
 	)
 
 	cfg, errs := builder.Build(t.Context())

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -649,6 +649,596 @@ func TestWithInheritance_CrossScope_ConflictingLeafHigherPriorityWins(t *testing
 	assert.Equal(t, "storage", shardingLogin)
 }
 
+// arrayReplaceCase is a single fixture for the table-driven array-opaque
+// suite below. listenLow / listenHigh become the global-scope and
+// instance-scope iproto.listen values; want is the expected result on the
+// instance's effective view.
+type arrayReplaceCase struct {
+	name       string
+	listenLow  any
+	listenHigh any
+	want       any
+}
+
+// TestWithInheritance_CrossScope_NestedArrayShapes pins that array nodes
+// nested inside a deep-merged map are always replaced wholesale by the
+// higher-priority scope, regardless of element shape (maps, scalars,
+// nested arrays, empty). No index-by-index merge ever leaks an orphan
+// lower-priority element into the effective view.
+func TestWithInheritance_CrossScope_NestedArrayShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []arrayReplaceCase{
+		{
+			name: "ArrayOfMaps_HigherShorter",
+			listenLow: []any{
+				map[string]any{"uri": "g1"},
+				map[string]any{"uri": "g2"},
+				map[string]any{"uri": "g3"},
+			},
+			listenHigh: []any{
+				map[string]any{"uri": "i1"},
+				map[string]any{"uri": "i2"},
+			},
+			want: []any{
+				map[string]any{"uri": "i1"},
+				map[string]any{"uri": "i2"},
+			},
+		},
+		{
+			name:       "ArrayOfScalars_HigherShorter",
+			listenLow:  []any{"g1", "g2", "g3"},
+			listenHigh: []any{"i1"},
+			want:       []any{"i1"},
+		},
+		{
+			name: "ArrayOfArrays",
+			listenLow: []any{
+				[]any{"g1a", "g1b"},
+				[]any{"g2a", "g2b"},
+			},
+			listenHigh: []any{
+				[]any{"i1a"},
+			},
+			want: []any{
+				[]any{"i1a"},
+			},
+		},
+		{
+			name: "HigherLongerThanLower",
+			listenLow: []any{
+				map[string]any{"uri": "g1"},
+			},
+			listenHigh: []any{
+				map[string]any{"uri": "i1"},
+				map[string]any{"uri": "i2"},
+				map[string]any{"uri": "i3"},
+			},
+			want: []any{
+				map[string]any{"uri": "i1"},
+				map[string]any{"uri": "i2"},
+				map[string]any{"uri": "i3"},
+			},
+		},
+		{
+			name:       "HigherEmptyClears",
+			listenLow:  []any{"g1", "g2"},
+			listenHigh: []any{},
+			want:       []any{},
+		},
+		{
+			name: "ArrayOfMaps_DisjointSubkeysNotMergedPerIndex",
+			listenLow: []any{
+				map[string]any{"a": 1},
+			},
+			listenHigh: []any{
+				map[string]any{"b": 2},
+			},
+			// If index-merging leaked through, this would be {a: 1, b: 2}.
+			want: []any{
+				map[string]any{"b": 2},
+			},
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder := config.NewBuilder()
+
+			builder = builder.AddCollector(collectors.NewMap(map[string]any{
+				"iproto": map[string]any{
+					"listen": tcase.listenLow,
+				},
+				"groups": map[string]any{
+					"storages": map[string]any{
+						"replicasets": map[string]any{
+							"s-001": map[string]any{
+								"instances": map[string]any{
+									"s-001-a": map[string]any{
+										"iproto": map[string]any{
+											"listen": tcase.listenHigh,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}).WithName("test").WithSourceType(config.FileSource))
+
+			builder = builder.WithInheritance(
+				config.Levels(config.Global, "groups", "replicasets", "instances"),
+			)
+
+			cfg, errs := builder.Build(t.Context())
+			require.Empty(t, errs)
+
+			eff, err := cfg.Effective(
+				config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+			require.NoError(t, err)
+
+			var got any
+
+			_, err = eff.Get(config.NewKeyPath("iproto/listen"), &got)
+			require.NoError(t, err)
+			assert.Equal(t, tcase.want, got)
+		})
+	}
+}
+
+// TestWithInheritance_CrossScope_TopLevelArrayWholesaleReplace pins the
+// invariant when the array sits directly at the top level of the config
+// (not nested under a deep-merged map). The MergeReplace fallback path in
+// mergeIntoResult handles this case; the nested case goes through
+// deepMergeNodes. Both must agree.
+func TestWithInheritance_CrossScope_TopLevelArrayWholesaleReplace(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"top_list": []any{"g1", "g2", "g3"},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"top_list": []any{"i1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var got []any
+
+	_, err = eff.Get(config.NewKeyPath("top_list"), &got)
+	require.NoError(t, err)
+	assert.Equal(t, []any{"i1"}, got)
+}
+
+// TestWithInheritance_CrossScope_MapSiblingsPreservedWithArrayReplace
+// verifies that under the same deep-merged parent map, sibling map sub-keys
+// still deep-merge while sibling arrays still wholesale-replace. This is
+// the combined invariant — arrays opaque, maps recursive, both at the same
+// time under one parent.
+func TestWithInheritance_CrossScope_MapSiblingsPreservedWithArrayReplace(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer":     map[string]any{"login": "replicator"},
+				"sharding": map[string]any{"login": "storage"},
+			},
+			"listen": []any{
+				map[string]any{"uri": "g1"},
+				map[string]any{"uri": "g2"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"advertise": map[string]any{
+										"peer": map[string]any{"login": "replicator-instance"},
+									},
+									"listen": []any{
+										map[string]any{"uri": "i1"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// Map merge: instance wins on the conflicting leaf, sibling sub-key
+	// from global survives.
+	var peerLogin string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/advertise/peer/login"), &peerLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "replicator-instance", peerLogin)
+
+	var shardingLogin string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/advertise/sharding/login"), &shardingLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "storage", shardingLogin)
+
+	// Array replace: instance fully replaces global, no leaked global[1].
+	var listen []map[string]string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	require.Len(t, listen, 1)
+	assert.Equal(t, "i1", listen[0]["uri"])
+}
+
+// TestWithInheritance_CrossScope_ThreeLevelArrayReplace verifies the
+// invariant holds across the full Global → group → replicaset → instance
+// chain — each scope sets the same array path, and only the highest scope
+// that defines it wins (not any partial merge with intermediate scopes).
+func TestWithInheritance_CrossScope_ThreeLevelArrayReplace(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"listen": []any{"global-1", "global-2", "global-3", "global-4"},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"iproto": map[string]any{
+					"listen": []any{"group-1", "group-2", "group-3"},
+				},
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"iproto": map[string]any{
+							"listen": []any{"replicaset-1", "replicaset-2"},
+						},
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"listen": []any{"instance-1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var listen []any
+
+	_, err = eff.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	assert.Equal(t, []any{"instance-1"}, listen)
+}
+
+// TestWithInheritance_CrossScope_ArrayMapTypeMismatch exercises the type
+// boundary: when one scope has an array at a path and another has a map at
+// the same path, the higher-priority scope wins wholesale (no attempt to
+// merge incompatible shapes). Runs both directions.
+func TestWithInheritance_CrossScope_ArrayMapTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ArrayLow_MapHigh", func(t *testing.T) {
+		t.Parallel()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"thing": []any{"g1", "g2"},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{
+									"thing": map[string]any{"key": "value"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test").WithSourceType(config.FileSource))
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got map[string]string
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "value"}, got)
+	})
+
+	t.Run("MapLow_ArrayHigh", func(t *testing.T) {
+		t.Parallel()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"thing": map[string]any{"a": 1, "b": 2},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{
+									"thing": []any{"i1", "i2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test").WithSourceType(config.FileSource))
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got []any
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"i1", "i2"}, got)
+
+		// Map sub-keys must be gone.
+		_, err = eff.Get(config.NewKeyPath("thing/a"), new(int))
+		require.Error(t, err)
+	})
+}
+
+// TestWithInheritance_CrossScope_ArrayScalarTypeMismatch verifies the
+// scalar boundary: array ↔ scalar at the same path, higher-priority wins
+// wholesale in both directions.
+func TestWithInheritance_CrossScope_ArrayScalarTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ArrayLow_ScalarHigh", func(t *testing.T) {
+		t.Parallel()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"thing": []any{"g1", "g2"},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{"thing": "scalar"},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test").WithSourceType(config.FileSource))
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got string
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, "scalar", got)
+	})
+
+	t.Run("ScalarLow_ArrayHigh", func(t *testing.T) {
+		t.Parallel()
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(collectors.NewMap(map[string]any{
+			"thing": "scalar",
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{
+								"s-001-a": map[string]any{"thing": []any{"i1", "i2"}},
+							},
+						},
+					},
+				},
+			},
+		}).WithName("test").WithSourceType(config.FileSource))
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got []any
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"i1", "i2"}, got)
+	})
+}
+
+// TestWithInheritance_CrossScope_ExplicitMergeAppendStillAppends verifies
+// that opt-in MergeAppend on a nested array still appends across scopes —
+// the array-opaque default does not break the explicit append strategy.
+func TestWithInheritance_CrossScope_ExplicitMergeAppendStillAppends(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"listen": []any{"g1", "g2"},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"iproto": map[string]any{
+									"listen": []any{"i1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("iproto/listen", config.MergeAppend),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var listen []string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"g1", "g2", "i1"}, listen)
+}
+
+// TestWithInheritance_CrossScope_ExplicitMergeReplaceMap verifies that
+// opt-in MergeReplace on a map sub-key still wholesale-replaces (i.e. the
+// MergeDeep default does not bleed into explicit MergeReplace usage).
+func TestWithInheritance_CrossScope_ExplicitMergeReplaceMap(t *testing.T) {
+	t.Parallel()
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"admin":   map[string]any{"password": "admin-global"},
+				"monitor": map[string]any{"password": "monitor-global"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{
+							"s-001-a": map[string]any{
+								"credentials": map[string]any{
+									"users": map[string]any{
+										"replicator": map[string]any{"password": "rep-instance"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).WithName("test").WithSourceType(config.FileSource))
+
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("credentials/users", config.MergeReplace),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var users map[string]any
+
+	_, err = eff.Get(config.NewKeyPath("credentials/users"), &users)
+	require.NoError(t, err)
+	require.Len(t, users, 1, "explicit MergeReplace must wholesale-replace the map")
+	assert.Contains(t, users, "replicator")
+	assert.NotContains(t, users, "admin")
+	assert.NotContains(t, users, "monitor")
+}
+
 func TestWithInheritance_ChildOverridesParent(t *testing.T) {
 	t.Parallel()
 

--- a/layered_extra_test.go
+++ b/layered_extra_test.go
@@ -737,3 +737,332 @@ func TestLayered_CrossLoader_ArrayMapTypeMismatch(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Cross-loader: explicit MergeReplace means wholesale replace, both axes
+// ---------------------------------------------------------------------------.
+
+// TestLayered_CrossLoader_ExplicitMergeReplaceMap_WholesaleReplaces verifies
+// that a user who explicitly opts into MergeReplace for a map key gets
+// wholesale replace across loaders — exactly as they would within a single
+// loader's scope chain. The previous accumulateLayerResult special-case
+// silently recursed map merges for MergeReplace, contradicting both the
+// constant's docstring and the matching scope-chain test
+// TestWithInheritance_CrossScope_ExplicitMergeReplaceMap.
+func TestLayered_CrossLoader_ExplicitMergeReplaceMap_WholesaleReplaces(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"admin":   map[string]any{"password": "admin-file"},
+				"monitor": map[string]any{"password": "monitor-file"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"replicator": map[string]any{"password": "rep-env"},
+			},
+		},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader) // lower priority.
+	builder = builder.AddCollector(envLoader)  // higher priority.
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("credentials/users", config.MergeReplace),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var users map[string]any
+
+	_, err = eff.Get(config.NewKeyPath("credentials/users"), &users)
+	require.NoError(t, err)
+	require.Len(t, users, 1,
+		"explicit cross-loader MergeReplace must wholesale-replace the map, not recurse")
+	assert.Contains(t, users, "replicator")
+	assert.NotContains(t, users, "admin")
+	assert.NotContains(t, users, "monitor")
+}
+
+// TestLayered_CrossLoader_ExplicitMergeReplaceMatchesScopeChain pins the
+// stronger invariant: the same explicit MergeReplace strategy produces an
+// identical effective view whether the conflicting maps come from two
+// scopes of one loader or two separate loaders. Catches regressions where
+// the two paths drift apart again.
+func TestLayered_CrossLoader_ExplicitMergeReplaceMatchesScopeChain(t *testing.T) {
+	t.Parallel()
+
+	build := func(crossLoader bool) config.Config {
+		t.Helper()
+
+		lowVal := map[string]any{
+			"users": map[string]any{
+				"admin":   map[string]any{"password": "admin-low"},
+				"monitor": map[string]any{"password": "monitor-low"},
+			},
+		}
+		highVal := map[string]any{
+			"users": map[string]any{
+				"replicator": map[string]any{"password": "rep-high"},
+			},
+		}
+
+		builder := config.NewBuilder()
+
+		if crossLoader {
+			builder = builder.AddCollector(collectors.NewMap(map[string]any{
+				"credentials": lowVal,
+				"groups": map[string]any{
+					"storages": map[string]any{
+						"replicasets": map[string]any{
+							"s-001": map[string]any{
+								"instances": map[string]any{"s-001-a": map[string]any{}},
+							},
+						},
+					},
+				},
+			}).WithName("low").WithSourceType(config.FileSource))
+			builder = builder.AddCollector(collectors.NewMap(map[string]any{
+				"credentials": highVal,
+			}).WithName("high").WithSourceType(config.EnvSource))
+		} else {
+			builder = builder.AddCollector(collectors.NewMap(map[string]any{
+				"credentials": lowVal,
+				"groups": map[string]any{
+					"storages": map[string]any{
+						"replicasets": map[string]any{
+							"s-001": map[string]any{
+								"instances": map[string]any{
+									"s-001-a": map[string]any{
+										"credentials": highVal,
+									},
+								},
+							},
+						},
+					},
+				},
+			}).WithName("only").WithSourceType(config.FileSource))
+		}
+
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+			config.WithInheritMerge("credentials/users", config.MergeReplace),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		return cfg
+	}
+
+	for _, label := range []string{"single-loader-scope-chain", "cross-loader"} {
+		cfg := build(label == "cross-loader")
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err, label)
+
+		var users map[string]any
+
+		_, err = eff.Get(config.NewKeyPath("credentials/users"), &users)
+		require.NoError(t, err, label)
+		require.Len(t, users, 1, label)
+		assert.Contains(t, users, "replicator", label)
+		assert.NotContains(t, users, "admin", label)
+	}
+}
+
+// TestLayered_CrossLoader_ExplicitReplaceLeavesDefaultsAlone verifies that
+// using explicit MergeReplace on one specific key path does not bleed into
+// sibling keys — those still use the default deep-merge across loaders.
+// Catches a regression where removing the cross-loader MergeReplace
+// special-case might accidentally degrade default behavior elsewhere.
+func TestLayered_CrossLoader_ExplicitReplaceLeavesDefaultsAlone(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"admin": map[string]any{"password": "admin-file"},
+			},
+			"settings": map[string]any{
+				"timeout": 30,
+				"retries": 3,
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"credentials": map[string]any{
+			"users": map[string]any{
+				"replicator": map[string]any{"password": "rep-env"},
+			},
+			"settings": map[string]any{
+				"timeout": 60,
+			},
+		},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader)
+	builder = builder.AddCollector(envLoader)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+		config.WithInheritMerge("credentials/users", config.MergeReplace),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// credentials/users — explicit MergeReplace: only env's contribution.
+	var users map[string]any
+
+	_, err = eff.Get(config.NewKeyPath("credentials/users"), &users)
+	require.NoError(t, err)
+	require.Len(t, users, 1)
+	assert.Contains(t, users, "replicator")
+	assert.NotContains(t, users, "admin")
+
+	// credentials/settings — default (MergeDeep): both timeout (env override)
+	// and retries (file only) must survive.
+	var timeout, retries int
+
+	_, err = eff.Get(config.NewKeyPath("credentials/settings/timeout"), &timeout)
+	require.NoError(t, err)
+	assert.Equal(t, 60, timeout, "env wins on conflict for default-strategy leaf")
+
+	_, err = eff.Get(config.NewKeyPath("credentials/settings/retries"), &retries)
+	require.NoError(t, err, "file's retries sibling must survive default deep merge")
+	assert.Equal(t, 3, retries)
+}
+
+// TestLayered_CrossLoader_ExplicitMergeReplaceTypeMismatch exercises the
+// explicit-MergeReplace path with incompatible shapes (map ↔ array, map ↔
+// scalar) across loaders. The higher-priority loader always wins
+// wholesale, with no attempt to merge incompatible nodes.
+func TestLayered_CrossLoader_ExplicitMergeReplaceTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MapLow_ArrayHigh", func(t *testing.T) {
+		t.Parallel()
+
+		fileLoader := collectors.NewMap(map[string]any{
+			"thing": map[string]any{"a": 1, "b": 2},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{"s-001-a": map[string]any{}},
+						},
+					},
+				},
+			},
+		}).WithName("file").WithSourceType(config.FileSource)
+
+		envLoader := collectors.NewMap(map[string]any{
+			"thing": []any{"e1", "e2"},
+		}).WithName("env").WithSourceType(config.EnvSource)
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(fileLoader)
+		builder = builder.AddCollector(envLoader)
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+			config.WithInheritMerge("thing", config.MergeReplace),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got []any
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"e1", "e2"}, got)
+
+		_, err = eff.Get(config.NewKeyPath("thing/a"), new(int))
+		require.Error(t, err, "map sub-keys must be gone")
+	})
+
+	t.Run("MapLow_ScalarHigh", func(t *testing.T) {
+		t.Parallel()
+
+		fileLoader := collectors.NewMap(map[string]any{
+			"thing": map[string]any{"a": 1, "b": 2},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{"s-001-a": map[string]any{}},
+						},
+					},
+				},
+			},
+		}).WithName("file").WithSourceType(config.FileSource)
+
+		envLoader := collectors.NewMap(map[string]any{
+			"thing": "scalar",
+		}).WithName("env").WithSourceType(config.EnvSource)
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(fileLoader)
+		builder = builder.AddCollector(envLoader)
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+			config.WithInheritMerge("thing", config.MergeReplace),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got string
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, "scalar", got)
+	})
+}

--- a/layered_extra_test.go
+++ b/layered_extra_test.go
@@ -505,3 +505,235 @@ func TestLayered_MultiCollector_CountsAsOneLayer(t *testing.T) {
 		"higher-priority top-level collector must beat the whole MultiCollector layer")
 	assert.Equal(t, "top", m.Source.Name)
 }
+
+// ---------------------------------------------------------------------------
+// Cross-loader: arrays are opaque to map-merge (mergeTreeInto path)
+// ---------------------------------------------------------------------------.
+
+// TestLayered_CrossLoader_NestedArrayWholesaleReplace is the cross-loader
+// twin of TestWithInheritance_CrossScope_NestedArrayShapes: arrays nested
+// inside a deep-merged map must be replaced wholesale by the higher-priority
+// loader, with no index-by-index merge that would leak orphan elements.
+func TestLayered_CrossLoader_NestedArrayWholesaleReplace(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"listen": []any{
+				map[string]any{"uri": "file-1"},
+				map[string]any{"uri": "file-2"},
+				map[string]any{"uri": "file-3"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"listen": []any{
+				map[string]any{"uri": "env-1"},
+			},
+		},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader) // lower priority.
+	builder = builder.AddCollector(envLoader)  // higher priority.
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	var listen []map[string]string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	require.Len(t, listen, 1, "env loader's iproto.listen must replace file loader's wholesale")
+	assert.Equal(t, "env-1", listen[0]["uri"])
+}
+
+// TestLayered_CrossLoader_MapSiblingsPreservedWithArrayReplace verifies the
+// combined invariant for cross-loader merging: sibling map sub-keys still
+// deep-merge across loaders while sibling arrays still wholesale-replace.
+func TestLayered_CrossLoader_MapSiblingsPreservedWithArrayReplace(t *testing.T) {
+	t.Parallel()
+
+	fileLoader := collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer":     map[string]any{"login": "replicator"},
+				"sharding": map[string]any{"login": "storage"},
+			},
+			"listen": []any{
+				map[string]any{"uri": "file-1"},
+				map[string]any{"uri": "file-2"},
+			},
+		},
+		"groups": map[string]any{
+			"storages": map[string]any{
+				"replicasets": map[string]any{
+					"s-001": map[string]any{
+						"instances": map[string]any{"s-001-a": map[string]any{}},
+					},
+				},
+			},
+		},
+	}).WithName("file").WithSourceType(config.FileSource)
+
+	envLoader := collectors.NewMap(map[string]any{
+		"iproto": map[string]any{
+			"advertise": map[string]any{
+				"peer": map[string]any{"login": "replicator-env"},
+			},
+			"listen": []any{
+				map[string]any{"uri": "env-1"},
+			},
+		},
+	}).WithName("env").WithSourceType(config.EnvSource)
+
+	builder := config.NewBuilder()
+
+	builder = builder.AddCollector(fileLoader)
+	builder = builder.AddCollector(envLoader)
+	builder = builder.WithInheritance(
+		config.Levels(config.Global, "groups", "replicasets", "instances"),
+	)
+
+	cfg, errs := builder.Build(t.Context())
+	require.Empty(t, errs)
+
+	eff, err := cfg.Effective(
+		config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+	require.NoError(t, err)
+
+	// Map merge: env wins on the conflicting leaf, sibling sub-key from
+	// file loader survives.
+	var peerLogin string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/advertise/peer/login"), &peerLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "replicator-env", peerLogin)
+
+	var shardingLogin string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/advertise/sharding/login"), &shardingLogin)
+	require.NoError(t, err)
+	assert.Equal(t, "storage", shardingLogin)
+
+	// Array replace: env fully replaces file, no leaked file[1].
+	var listen []map[string]string
+
+	_, err = eff.Get(config.NewKeyPath("iproto/listen"), &listen)
+	require.NoError(t, err)
+	require.Len(t, listen, 1)
+	assert.Equal(t, "env-1", listen[0]["uri"])
+}
+
+// TestLayered_CrossLoader_ArrayMapTypeMismatch exercises the type-boundary
+// invariant across loaders: when one loader has an array and another has
+// a map at the same path, the higher-priority loader wins wholesale.
+func TestLayered_CrossLoader_ArrayMapTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ArrayLow_MapHigh", func(t *testing.T) {
+		t.Parallel()
+
+		fileLoader := collectors.NewMap(map[string]any{
+			"thing": []any{"f1", "f2"},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{"s-001-a": map[string]any{}},
+						},
+					},
+				},
+			},
+		}).WithName("file").WithSourceType(config.FileSource)
+
+		envLoader := collectors.NewMap(map[string]any{
+			"thing": map[string]any{"key": "value"},
+		}).WithName("env").WithSourceType(config.EnvSource)
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(fileLoader)
+		builder = builder.AddCollector(envLoader)
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got map[string]string
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "value"}, got)
+	})
+
+	t.Run("MapLow_ArrayHigh", func(t *testing.T) {
+		t.Parallel()
+
+		fileLoader := collectors.NewMap(map[string]any{
+			"thing": map[string]any{"a": 1, "b": 2},
+			"groups": map[string]any{
+				"storages": map[string]any{
+					"replicasets": map[string]any{
+						"s-001": map[string]any{
+							"instances": map[string]any{"s-001-a": map[string]any{}},
+						},
+					},
+				},
+			},
+		}).WithName("file").WithSourceType(config.FileSource)
+
+		envLoader := collectors.NewMap(map[string]any{
+			"thing": []any{"e1", "e2"},
+		}).WithName("env").WithSourceType(config.EnvSource)
+
+		builder := config.NewBuilder()
+
+		builder = builder.AddCollector(fileLoader)
+		builder = builder.AddCollector(envLoader)
+		builder = builder.WithInheritance(
+			config.Levels(config.Global, "groups", "replicasets", "instances"),
+		)
+
+		cfg, errs := builder.Build(t.Context())
+		require.Empty(t, errs)
+
+		eff, err := cfg.Effective(
+			config.NewKeyPath("groups/storages/replicasets/s-001/instances/s-001-a"))
+		require.NoError(t, err)
+
+		var got []any
+
+		_, err = eff.Get(config.NewKeyPath("thing"), &got)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"e1", "e2"}, got)
+
+		_, err = eff.Get(config.NewKeyPath("thing/a"), new(int))
+		require.Error(t, err)
+	})
+}

--- a/merge.go
+++ b/merge.go
@@ -125,24 +125,29 @@ func mergeNodeValue(node *tree.Node, value any, col Collector) {
 	//
 	// Slices are always replaced completely (no element‑wise merging).
 	// Primitives are replaced.
+	// Array nodes are treated as opaque (replaced wholesale) — they are not
+	// maps even though they are non-leaf.
 	m, newIsMap := value.(map[string]any)
-	currentIsMap := !node.IsLeaf()
+	currentIsMap := isMapNode(node)
 
 	if newIsMap {
 		if currentIsMap {
 			// Recursive map merging.
 			mergeMapIntoNode(node, m, col)
 		} else {
-			// Convert leaf to map: clear leaf value, then merge map into children.
+			// Convert leaf or array to map: clear value, drop array flag,
+			// drop existing children, then merge the map into a clean slate.
 			node.ClearChildren()
+			node.UnmarkArray()
 
 			node.Value = nil
 			mergeMapIntoNode(node, m, col)
 		}
 	} else {
 		// Replacement (primitive, slice, or map overwriting non‑map).
-		// Clear children and reset order flag.
+		// Clear children, drop array flag, reset order flag.
 		node.ClearChildren()
+		node.UnmarkArray()
 
 		node.Value = value
 	}

--- a/merge.go
+++ b/merge.go
@@ -174,8 +174,10 @@ func copyAnnotation(root *tree.Node, path keypath.KeyPath, src Value) {
 }
 
 // mergeTreeInto folds src into dst at the tree level.
-// Map-into-map is recursive; any other src child replaces the dst child
-// (carrying Source, Revision, Range, annotation, and isArray).
+// Map-into-map is recursive; any other src child (leaf or array) replaces
+// the dst child wholesale (carrying Source, Revision, Range, annotation,
+// and isArray). Arrays are opaque — index-merging would leak orphan
+// lower-priority indices into the result.
 // When src.OrderSet() and !dst.OrderSet() the dst children are reordered
 // to match src's key order and dst.OrderSet() is set true.
 func mergeTreeInto(dst, src *tree.Node) {
@@ -183,8 +185,8 @@ func mergeTreeInto(dst, src *tree.Node) {
 		srcChild := src.Child(key)
 		dstChild := dst.Child(key)
 
-		// Both sides are non-leaf maps → recurse.
-		if dstChild != nil && !dstChild.IsLeaf() && !srcChild.IsLeaf() {
+		// Both sides must be maps (not leaves, not arrays) to recurse.
+		if isMapNode(dstChild) && isMapNode(srcChild) {
 			// Carry ordering before recursing so children see the right dst state.
 			if srcChild.OrderSet() && !dstChild.OrderSet() {
 				_ = dstChild.ReorderChildren(srcChild.ChildrenKeys())

--- a/merge_test.go
+++ b/merge_test.go
@@ -381,3 +381,123 @@ func (v *multiErrorValue) Meta() meta.Info {
 		Revision: "",
 	}
 }
+
+// TestMergeCollector_ArrayToMapConversion pins the array-aware branch of
+// mergeNodeValue. Collector A builds an array node at `things` (numeric
+// segments turn it into a real array node with isArray=true). Collector B
+// then writes a map at the same `things` path. The result must be a clean
+// map node — no leftover indexed children and no isArray flag — not the
+// hybrid node that the older `!IsLeaf()` map-detection would produce.
+func TestMergeCollector_ArrayToMapConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	col1 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things/0"), "a").
+		WithEntry(config.NewKeyPath("things/1"), "b").
+		WithName("first")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col1))
+
+	thingsNode := root.Get(config.NewKeyPath("things"))
+	require.NotNil(t, thingsNode)
+	require.True(t, thingsNode.IsArray(), "sanity: should be an array node after numeric-key build")
+
+	col2 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things"), map[string]any{
+			"port": 9090,
+			"host": "localhost",
+		}).
+		WithName("second")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col2))
+
+	thingsNode = root.Get(config.NewKeyPath("things"))
+	require.NotNil(t, thingsNode)
+	assert.False(t, thingsNode.IsArray(),
+		"node converted from array to map must drop isArray flag")
+	assert.False(t, thingsNode.IsLeaf())
+	assert.Nil(t, thingsNode.Value)
+
+	keys := thingsNode.ChildrenKeys()
+	assert.ElementsMatch(t, []string{"port", "host"}, keys,
+		"only the new map keys should remain — no leaked array indices")
+
+	portNode := thingsNode.Child("port")
+	require.NotNil(t, portNode)
+	assert.Equal(t, 9090, portNode.Value)
+
+	hostNode := thingsNode.Child("host")
+	require.NotNil(t, hostNode)
+	assert.Equal(t, "localhost", hostNode.Value)
+
+	// ToAny should reflect a pure map.
+	raw := tree.ToAny(thingsNode)
+	assert.Equal(t, map[string]any{
+		"port": 9090,
+		"host": "localhost",
+	}, raw)
+}
+
+// TestMergeCollector_ArrayToScalarConversion checks the same boundary for
+// the leaf-replace branch: array → scalar must clear isArray and indexed
+// children, leaving a pure leaf node.
+func TestMergeCollector_ArrayToScalarConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	col1 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things/0"), "a").
+		WithEntry(config.NewKeyPath("things/1"), "b").
+		WithName("first")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col1))
+
+	require.True(t, root.Get(config.NewKeyPath("things")).IsArray())
+
+	col2 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things"), "scalar").
+		WithName("second")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col2))
+
+	thingsNode := root.Get(config.NewKeyPath("things"))
+	require.NotNil(t, thingsNode)
+	assert.True(t, thingsNode.IsLeaf())
+	assert.False(t, thingsNode.IsArray())
+	assert.Equal(t, "scalar", thingsNode.Value)
+	assert.Empty(t, thingsNode.ChildrenKeys())
+}
+
+// TestMergeCollector_MapToArrayConversion verifies the symmetric direction:
+// a map node followed by an array value (a slice leaf) wholesale-replaces
+// into a leaf with the slice as its Value (mirrors TestMergeCollector_
+// SliceReplacement but starting from a real map node, not a slice leaf).
+func TestMergeCollector_MapToArrayConversion(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+
+	col1 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things"), map[string]any{
+			"port": 9090,
+			"host": "localhost",
+		}).
+		WithName("first")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col1))
+
+	thingsNode := root.Get(config.NewKeyPath("things"))
+	require.False(t, thingsNode.IsLeaf())
+	require.False(t, thingsNode.IsArray())
+
+	col2 := collectors.NewMock().
+		WithEntry(config.NewKeyPath("things"), []string{"x", "y", "z"}).
+		WithName("second")
+	require.NoError(t, config.MergeCollector(t.Context(), root, col2))
+
+	thingsNode = root.Get(config.NewKeyPath("things"))
+	require.NotNil(t, thingsNode)
+	assert.True(t, thingsNode.IsLeaf(), "slice values land on the leaf branch")
+	assert.False(t, thingsNode.IsArray())
+	assert.Equal(t, []string{"x", "y", "z"}, thingsNode.Value)
+	assert.Empty(t, thingsNode.ChildrenKeys(),
+		"all prior map children must be cleared")
+}

--- a/tree/node.go
+++ b/tree/node.go
@@ -89,6 +89,12 @@ func (n *Node) MarkArray() {
 	n.isArray = true
 }
 
+// UnmarkArray clears the array flag, e.g. when a path that previously held
+// an array is being converted into a map by an overriding contribution.
+func (n *Node) UnmarkArray() {
+	n.isArray = false
+}
+
 // Children returns the child nodes in insertion order.
 func (n *Node) Children() []*Node {
 	if n.children == nil {

--- a/tree/node_test.go
+++ b/tree/node_test.go
@@ -814,3 +814,31 @@ func TestNode_IsArray_LeafNode(t *testing.T) {
 	node.MarkArray()
 	assert.True(t, node.IsArray())
 }
+
+func TestNode_UnmarkArray(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	node.MarkArray()
+	require.True(t, node.IsArray())
+
+	node.UnmarkArray()
+	assert.False(t, node.IsArray(),
+		"UnmarkArray must drop the array flag so the node is no longer treated as a sequence")
+}
+
+func TestNode_UnmarkArray_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	node := tree.New()
+	require.False(t, node.IsArray())
+
+	node.UnmarkArray()
+	assert.False(t, node.IsArray(),
+		"UnmarkArray on an already-non-array node must be a no-op")
+
+	node.MarkArray()
+	node.UnmarkArray()
+	node.UnmarkArray()
+	assert.False(t, node.IsArray())
+}


### PR DESCRIPTION
foldScopeChainInto used MergeReplace as the implicit default, which wholesale-replaced any top-level map a higher-priority scope touched even if it only set one nested sub-key. The cross-loader accumulator (accumulateLayerResult) already special-cased MergeReplace to recursively merge map nodes — single-loader scope-chain resolution did not.

The two-scope mismatch silently dropped data in real Tarantool configs: a group declaring roles_cfg.<role>.advertise.params.transport disappeared as soon as an instance set roles_cfg.<role>.advertise.uri, and a global iproto.advertise.{sharding,peer}.login was wiped by any instance that declared iproto.listen.

- Make MergeDeep the default returned by strategyFor when no explicit per-key strategy is registered. Leaf semantics (higher-priority wins) are unchanged; maps now recursively merge end-to-end. Explicit WithInheritMerge(key, MergeReplace) still means wholesale replace.
- Prune WithNoInherit and WithNoInheritFrom prefixes from each non-leaf layer before folding, mirroring the tombstone path. Nested-path exclusions were previously checked only against top-level iteration keys and never matched anything deeper.
- Add TestWithInheritance_CrossScope_{NonConflictingSubkeysCoexist, ConflictingLeafHigherPriorityWins} as scope-chain analogues of the existing TestLayered_CrossLoader_* invariants.
