### PR TITLE
tree: fix empty array decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   YAML 1.2 core schema but booleans/nulls under YAML 1.1 (`off`, `on`, `yes`,
   `no`, ...), so re-emitted documents are not misread by YAML 1.1 loaders such
   as libyaml.
+* `nodeToValue` now reports an empty array node as an empty `[]any{}` slice
+  instead of `nil`, and preserves a slice assigned directly to an array node's
+  `Value` (with no child nodes) instead of flattening it to an empty slice.
 
 ## [v1.3.0] - 2026-05-19
 

--- a/tree/value.go
+++ b/tree/value.go
@@ -78,19 +78,30 @@ func (v *valueImpl) Annotation() any {
 }
 
 // nodeToValue converts a tree node into a generic Go value.
-// If the node is a leaf (no children), returns node.Value (which may be a slice, map, or primitive).
-// For array nodes, builds a []any from children in order.
-// Otherwise, builds a map[string]any from its children.
+//
+// Array nodes are handled before the leaf check: a populated array yields a
+// []any built from its children in order, while an empty array yields the
+// slice stored directly in node.Value (when set) or an empty []any{} rather
+// than nil. Consulting node.Value for an empty array mirrors tree.ToAny and
+// avoids dropping a slice assigned to an array node that has no children.
+//
+// A non-array leaf returns node.Value (which may be a slice, map, or
+// primitive). Otherwise the node is a map and a map[string]any is built from
+// its children.
 func nodeToValue(node *Node) any {
-	if node.IsLeaf() {
-		return node.Value
-	}
-
-	children := node.Children()
-	keys := node.ChildrenKeys()
-
-	// Array node - return slice.
 	if node.isArray {
+		if node.IsLeaf() {
+			// Empty array node: honor a slice stored directly in Value,
+			// otherwise yield an empty slice rather than nil.
+			if node.Value != nil {
+				return node.Value
+			}
+
+			return []any{}
+		}
+
+		children := node.Children()
+
 		result := make([]any, 0, len(children))
 		for _, child := range children {
 			result = append(result, nodeToValue(child))
@@ -98,6 +109,13 @@ func nodeToValue(node *Node) any {
 
 		return result
 	}
+
+	if node.IsLeaf() {
+		return node.Value
+	}
+
+	children := node.Children()
+	keys := node.ChildrenKeys()
 
 	// Map node - return map.
 	m := make(map[string]any, len(children))

--- a/tree/value_test.go
+++ b/tree/value_test.go
@@ -1714,3 +1714,73 @@ func TestValue_Get_UnsupportedDestinationKinds(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported")
 }
+
+func TestValue_Get_EmptyArrayNode_AsSlice(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("empty"), nil)
+
+	node := root.Get(keypath.NewKeyPath("empty"))
+	require.NotNil(t, node)
+	node.MarkArray()
+
+	require.True(t, node.IsLeaf())
+	require.True(t, node.IsArray())
+
+	val := tree.NewValue(node, keypath.NewKeyPath("empty"))
+
+	var got []any
+
+	err := val.Get(&got)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestValue_Get_EmptyArrayNode_AsAnyIsSlice(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("empty"), nil)
+
+	node := root.Get(keypath.NewKeyPath("empty"))
+	require.NotNil(t, node)
+	node.MarkArray()
+
+	val := tree.NewValue(node, keypath.NewKeyPath("empty"))
+
+	var got any
+
+	err := val.Get(&got)
+	require.NoError(t, err)
+
+	slice, ok := got.([]any)
+	require.True(t, ok)
+	assert.Empty(t, slice)
+}
+
+// An array-marked leaf that carries its slice directly in Value (no child
+// nodes) must not be flattened to an empty slice: handling the array branch
+// before the leaf check would otherwise drop the data.
+func TestValue_Get_ArrayNode_SliceInValue(t *testing.T) {
+	t.Parallel()
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("nums"), []any{1, 2, 3})
+
+	node := root.Get(keypath.NewKeyPath("nums"))
+	require.NotNil(t, node)
+	node.MarkArray()
+
+	require.True(t, node.IsLeaf())
+	require.True(t, node.IsArray())
+
+	val := tree.NewValue(node, keypath.NewKeyPath("nums"))
+
+	var got []int
+
+	err := val.Get(&got)
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, got)
+}


### PR DESCRIPTION
The check for an empty array has been changed. Previously, an empty
array became nil.