### PR TITLE
jsonschema: schema-aware null coercion with configurable scalar policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+* Schema-aware null coercion for JSON-Schema validation. Empty (null)
+  values are coerced to `{}` where the schema expects an object and `[]`
+  where it expects an array (resolving `$ref` and `allOf`/`anyOf`/`oneOf`).
+  The ambiguous scalar case is governed by a configurable
+  `jsonschema.NullCoercion` policy — `NullLeave` (default), `NullDrop`
+  (treat empty as unset) or `NullZero` (typed zero value) — set
+  per-validator via `jsonschema.WithNullCoercion`, per-build via
+  `Builder.WithJSONSchema` options or `tarantool.Builder.WithNullCoercion`,
+  or globally via `jsonschema.DefaultNullCoercion`.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* `tree.ToAny` no longer converts a null scalar leaf into an empty
+  `map[string]any{}`. An empty YAML value (e.g. `key:`) parses to such a
+  leaf, so it was materialized as an object and JSON-Schema validation
+  rejected it as `object but should be string/array`. It now yields
+  `nil`, matching `nodeToValue`. Empty mappings (`{}`) and empty
+  sequences (`[]`) keep their respective shapes.
+
 ## [v1.4.0] - 2026-06-09
 
 This release makes `MergeDeep` the default inheritance merge strategy (was

--- a/builder.go
+++ b/builder.go
@@ -64,12 +64,17 @@ func (b *Builder) WithValidator(validator validator.Validator) Builder {
 // WithJSONSchema creates a JSON Schema validator and sets it.
 // Returns ErrNilSchemaReader if schema is nil, or a wrapped error
 // if schema parsing fails. The Builder is returned unchanged on error.
-func (b *Builder) WithJSONSchema(schema io.Reader) (Builder, error) {
+//
+// Optional jsonschema.Option values configure the validator, e.g.
+// jsonschema.WithNullCoercion to control how empty (null) YAML values are
+// treated. Without an explicit option the global jsonschema.DefaultNullCoercion
+// applies.
+func (b *Builder) WithJSONSchema(schema io.Reader, opts ...jsonschema.Option) (Builder, error) {
 	if schema == nil {
 		return *b, fmt.Errorf("failed to create JSON schema validator: %w", ErrNilSchemaReader)
 	}
 
-	validator, err := jsonschema.NewFromReader(schema)
+	validator, err := jsonschema.NewFromReader(schema, opts...)
 	if err != nil {
 		return *b, fmt.Errorf("failed to create JSON schema validator: %w", err)
 	}

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -12,6 +12,7 @@ import (
 	config "github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/collectors"
 	"github.com/tarantool/go-config/tarantool/internal/envpath"
+	"github.com/tarantool/go-config/validators/jsonschema"
 	"github.com/tarantool/go-storage/integrity"
 )
 
@@ -47,6 +48,8 @@ type Builder struct {
 	skipSchema     bool
 	skipValidation bool
 	httpClient     *http.Client
+
+	schemaOpts []jsonschema.Option
 
 	inheritanceOpts []config.InheritanceOption
 
@@ -201,6 +204,17 @@ func (b *Builder) WithoutSchema() *Builder {
 // (no schema is loaded in that case).
 func (b *Builder) WithoutValidation() *Builder {
 	b.skipValidation = true
+
+	return b
+}
+
+// WithNullCoercion sets how empty (null) YAML values are treated during schema
+// validation. Object- and array-typed empty values are always coerced to {} /
+// []; this knob governs the ambiguous scalar case (see
+// [jsonschema.NullCoercion]). Without it, the global
+// [jsonschema.DefaultNullCoercion] applies.
+func (b *Builder) WithNullCoercion(policy jsonschema.NullCoercion) *Builder {
+	b.schemaOpts = append(b.schemaOpts, jsonschema.WithNullCoercion(policy))
 
 	return b
 }
@@ -481,7 +495,7 @@ func (b *Builder) buildInner(ctx context.Context) (config.Builder, error) {
 
 	// 5. Schema validation.
 	if !b.skipSchema && !b.skipValidation {
-		inner, err = inner.WithJSONSchema(bytes.NewReader(schemaBytes))
+		inner, err = inner.WithJSONSchema(bytes.NewReader(schemaBytes), b.schemaOpts...)
 		if err != nil {
 			return config.Builder{}, fmt.Errorf("json schema: %w", err)
 		}

--- a/tarantool/builder_envschema_test.go
+++ b/tarantool/builder_envschema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tarantool/go-config"
 	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/validators/jsonschema"
 )
 
 const fixtureSchemaPath = "testdata/config.schema.json"
@@ -137,6 +138,41 @@ func TestBuild_Env_NoSchema_HeuristicUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "true", nonblock,
 		"without schema, naive split sends the value to the wrong path")
+}
+
+func TestBuild_NullCoercion_EmptyStringField(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	// wal_queue_max_size is a string field in the fixture schema, left empty
+	// (a null scalar) in the config.
+	writeFile(t, cfgPath, "wal_queue_max_size:\n")
+
+	ctx := context.Background()
+
+	// Default policy (NullLeave) keeps the null, which the string schema rejects.
+	_, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithSchemaFile(fixtureSchemaPath).
+		WithEnvPrefix("TT_TESTONLY_").
+		Build(ctx)
+	require.Error(t, err)
+
+	// WithNullCoercion(NullZero) coerces the empty value to "", so it validates.
+	cfg, err := tarantool.New().
+		WithConfigFile(cfgPath).
+		WithSchemaFile(fixtureSchemaPath).
+		WithEnvPrefix("TT_TESTONLY_").
+		WithNullCoercion(jsonschema.NullZero).
+		Build(ctx)
+	require.NoError(t, err)
+
+	var size string
+
+	_, err = cfg.Get(config.NewKeyPath("wal_queue_max_size"), &size)
+	require.NoError(t, err)
+	assert.Empty(t, size)
 }
 
 func TestBuild_WithoutValidation_KeepsSchemaAwareEnvRouting(t *testing.T) {

--- a/tree/convert.go
+++ b/tree/convert.go
@@ -5,6 +5,11 @@ package tree
 //   - primitive value for leaf nodes
 //   - []any for array nodes (nodes marked with MarkArray)
 //   - map[string]any for object nodes
+//
+// A leaf with a nil Value is a null scalar (e.g. an empty YAML value like
+// `key:`) and converts to nil. Empty mappings (`{}`) carry a non-nil
+// map[string]any{} Value and empty sequences (`[]`) are marked as arrays, so
+// both keep their respective empty-container shapes via the branches below.
 func ToAny(node *Node) any {
 	switch {
 	case node == nil:
@@ -14,7 +19,7 @@ func ToAny(node *Node) any {
 			return []any{}
 		}
 
-		return map[string]any{}
+		return nil
 	case node.IsLeaf():
 		return node.Value
 	}

--- a/tree/convert_test.go
+++ b/tree/convert_test.go
@@ -33,13 +33,9 @@ func TestToAny_Leaf(t *testing.T) {
 
 			result := tree.ToAny(node)
 
-			expected := tt.value
-			if tt.value == nil {
-				// Leaf with nil value converts to empty map (special case).
-				expected = map[string]any{}
-			}
-
-			assert.Equal(t, expected, result)
+			// A leaf with a nil Value is a null scalar and converts to nil
+			// (it must not be fabricated into an empty map/object).
+			assert.Equal(t, tt.value, result)
 		})
 	}
 }
@@ -68,10 +64,35 @@ func TestToAny_Nested(t *testing.T) {
 func TestToAny_EmptyNode(t *testing.T) {
 	t.Parallel()
 
+	// A bare node with no value and no children is treated as a null scalar.
 	node := tree.New()
 	result := tree.ToAny(node)
-	expected := map[string]any{}
-	assert.Equal(t, any(expected), result)
+	assert.Nil(t, result)
+}
+
+func TestToAny_NullScalarLeaf(t *testing.T) {
+	t.Parallel()
+
+	// A null scalar (e.g. an empty YAML value `key:`) must convert to nil,
+	// not to an empty object, so schema validation sees the declared type
+	// rather than rejecting it as an unexpected object.
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("key"), nil)
+
+	result := tree.ToAny(root)
+	assert.Equal(t, any(map[string]any{"key": nil}), result)
+}
+
+func TestToAny_EmptyMapLeaf(t *testing.T) {
+	t.Parallel()
+
+	// An explicit empty mapping carries a non-nil map Value and keeps its
+	// empty-object shape.
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("key"), map[string]any{})
+
+	result := tree.ToAny(root)
+	assert.Equal(t, any(map[string]any{"key": map[string]any{}}), result)
 }
 
 func TestToAny_MissingChild(t *testing.T) {

--- a/validators/jsonschema/coerce.go
+++ b/validators/jsonschema/coerce.go
@@ -1,0 +1,264 @@
+package jsonschema
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/kaptinlin/jsonschema"
+)
+
+// NullCoercion controls how a JSON null (produced by an empty YAML value such
+// as `key:`) is treated, just before validation, when the schema at that
+// location expects a scalar type (string, number, integer or boolean).
+//
+// Null values whose schema expects an object or an array are ALWAYS coerced to
+// an empty object ({}) or empty array ([]) respectively, regardless of this
+// setting: an empty mapping/sequence is the unambiguous YAML intent there. This
+// knob only governs the genuinely ambiguous scalar case.
+type NullCoercion int
+
+const (
+	// NullLeave keeps a scalar null as null. This is the JSON-Schema-pure
+	// behaviour: if the schema does not declare the field nullable
+	// (type includes "null"), validation will reject the null. Default.
+	NullLeave NullCoercion = iota
+	// NullDrop removes a null-valued scalar key from its parent object,
+	// treating an empty value as "unset" so the field falls back to its
+	// default. A required-but-empty field then fails as missing.
+	NullDrop
+	// NullZero replaces a scalar null with the zero value of the schema's
+	// declared type: "" for string, 0 for number/integer, false for boolean.
+	NullZero
+)
+
+// DefaultNullCoercion is the policy applied by validators created without an
+// explicit WithNullCoercion option. Set it once at startup to change the
+// behaviour globally.
+//
+//nolint:gochecknoglobals // intentional global default knob, set once at startup.
+var DefaultNullCoercion = NullLeave
+
+// dropMarker is returned by coerceNulls to signal that a null scalar key should
+// be removed from its parent object (NullDrop policy).
+type dropMarker struct{}
+
+// coerceNulls walks data alongside the schema and rewrites null values into the
+// empty shape the schema expects. Containers ({} / []) are always coerced;
+// scalars follow the policy. The (possibly mutated) data is returned.
+func coerceNulls(data any, schema *jsonschema.Schema, policy NullCoercion) any {
+	schema = effectiveSchema(schema)
+
+	switch typed := data.(type) {
+	case nil:
+		return coerceNull(schema, policy)
+	case map[string]any:
+		for key, child := range typed {
+			coerced := coerceNulls(child, subschemaForProperty(schema, key), policy)
+			if _, drop := coerced.(dropMarker); drop {
+				delete(typed, key)
+
+				continue
+			}
+
+			typed[key] = coerced
+		}
+
+		return typed
+	case []any:
+		for i, item := range typed {
+			coerced := coerceNulls(item, subschemaForItem(schema, i), policy)
+			// An array element cannot be dropped without shifting indices;
+			// fall back to leaving it null.
+			if _, drop := coerced.(dropMarker); drop {
+				coerced = nil
+			}
+
+			typed[i] = coerced
+		}
+
+		return typed
+	default:
+		return data
+	}
+}
+
+// coerceNull resolves a single null value against its schema.
+func coerceNull(schema *jsonschema.Schema, policy NullCoercion) any {
+	// An explicitly nullable schema accepts null as-is.
+	if schema != nil && schemaAllows(schema, "null") {
+		return nil
+	}
+
+	switch {
+	case schema != nil && schemaIsObject(schema):
+		return map[string]any{}
+	case schema != nil && schemaIsArray(schema):
+		return []any{}
+	}
+
+	switch policy {
+	case NullDrop:
+		return dropMarker{}
+	case NullZero:
+		return zeroForSchema(schema)
+	case NullLeave:
+		fallthrough
+	default:
+		return nil
+	}
+}
+
+// effectiveSchema follows $ref links to the concrete schema that actually
+// constrains the value. Combinators (allOf/anyOf/oneOf) are not collapsed here;
+// the schemaIs*/subschemaFor* helpers look through them where needed.
+func effectiveSchema(schema *jsonschema.Schema) *jsonschema.Schema {
+	seen := make(map[*jsonschema.Schema]struct{})
+
+	current := schema
+	for current != nil && current.Ref != "" && current.ResolvedRef != nil {
+		if _, ok := seen[current]; ok {
+			break
+		}
+
+		seen[current] = struct{}{}
+		current = current.ResolvedRef
+	}
+
+	return current
+}
+
+// schemaAllows reports whether the schema's type list includes the given type.
+func schemaAllows(schema *jsonschema.Schema, typ string) bool {
+	return slices.Contains([]string(schema.Type), typ)
+}
+
+// branches returns the combinator subschemas (allOf/anyOf/oneOf) of schema.
+func branches(schema *jsonschema.Schema) []*jsonschema.Schema {
+	out := make([]*jsonschema.Schema, 0, len(schema.AllOf)+len(schema.AnyOf)+len(schema.OneOf))
+
+	out = append(out, schema.AllOf...)
+	out = append(out, schema.AnyOf...)
+	out = append(out, schema.OneOf...)
+
+	return out
+}
+
+// schemaIsObject reports whether the schema describes an object, looking through
+// $ref and combinators.
+func schemaIsObject(schema *jsonschema.Schema) bool {
+	schema = effectiveSchema(schema)
+	if schema == nil {
+		return false
+	}
+
+	if len(schema.Type) > 0 {
+		return schemaAllows(schema, "object")
+	}
+
+	if schema.Properties != nil || schema.PatternProperties != nil ||
+		schema.AdditionalProperties != nil || len(schema.Required) > 0 {
+		return true
+	}
+
+	return slices.ContainsFunc(branches(schema), schemaIsObject)
+}
+
+// schemaIsArray reports whether the schema describes an array, looking through
+// $ref and combinators.
+func schemaIsArray(schema *jsonschema.Schema) bool {
+	schema = effectiveSchema(schema)
+	if schema == nil {
+		return false
+	}
+
+	if len(schema.Type) > 0 {
+		return schemaAllows(schema, "array")
+	}
+
+	if schema.Items != nil || len(schema.PrefixItems) > 0 {
+		return true
+	}
+
+	return slices.ContainsFunc(branches(schema), schemaIsArray)
+}
+
+// subschemaForProperty resolves the schema constraining property key of an
+// object schema, consulting properties, patternProperties, additionalProperties
+// and combinators.
+func subschemaForProperty(schema *jsonschema.Schema, key string) *jsonschema.Schema {
+	schema = effectiveSchema(schema)
+	if schema == nil {
+		return nil
+	}
+
+	if schema.Properties != nil {
+		if sub, ok := (*schema.Properties)[key]; ok {
+			return sub
+		}
+	}
+
+	if schema.PatternProperties != nil {
+		for pattern, sub := range *schema.PatternProperties {
+			re, err := regexp.Compile(pattern)
+			if err == nil && re.MatchString(key) {
+				return sub
+			}
+		}
+	}
+
+	for _, branch := range branches(schema) {
+		if sub := subschemaForProperty(branch, key); sub != nil {
+			return sub
+		}
+	}
+
+	if schema.AdditionalProperties != nil {
+		return schema.AdditionalProperties
+	}
+
+	return nil
+}
+
+// subschemaForItem resolves the schema constraining the array element at index.
+func subschemaForItem(schema *jsonschema.Schema, index int) *jsonschema.Schema {
+	schema = effectiveSchema(schema)
+	if schema == nil {
+		return nil
+	}
+
+	if index < len(schema.PrefixItems) {
+		return schema.PrefixItems[index]
+	}
+
+	if schema.Items != nil {
+		return schema.Items
+	}
+
+	for _, branch := range branches(schema) {
+		if sub := subschemaForItem(branch, index); sub != nil {
+			return sub
+		}
+	}
+
+	return nil
+}
+
+// zeroForSchema returns the zero value for the schema's declared scalar type.
+func zeroForSchema(schema *jsonschema.Schema) any {
+	if schema == nil {
+		return nil
+	}
+
+	switch {
+	case schemaAllows(schema, "string"):
+		return ""
+	case schemaAllows(schema, "boolean"):
+		return false
+	case schemaAllows(schema, "integer"):
+		return 0
+	case schemaAllows(schema, "number"):
+		return 0.0
+	default:
+		return nil
+	}
+}

--- a/validators/jsonschema/coerce_internal_test.go
+++ b/validators/jsonschema/coerce_internal_test.go
@@ -1,0 +1,27 @@
+package jsonschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCoerce_NilSchemaGuards exercises the defensive nil-schema branches that
+// the public Validate path rarely reaches: an absent subschema means the value
+// is unconstrained, so the helpers must report "not a container" and yield no
+// zero rather than panic.
+func TestCoerce_NilSchemaGuards(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, effectiveSchema(nil))
+	assert.False(t, schemaIsObject(nil))
+	assert.False(t, schemaIsArray(nil))
+	assert.Nil(t, subschemaForProperty(nil, "k"))
+	assert.Nil(t, subschemaForItem(nil, 0))
+	assert.Nil(t, zeroForSchema(nil))
+
+	// A nil schema under each policy yields the policy's empty-scalar result.
+	assert.Nil(t, coerceNull(nil, NullLeave))
+	assert.Nil(t, coerceNull(nil, NullZero))
+	assert.IsType(t, dropMarker{}, coerceNull(nil, NullDrop))
+}

--- a/validators/jsonschema/coerce_test.go
+++ b/validators/jsonschema/coerce_test.go
@@ -1,0 +1,334 @@
+package jsonschema_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/validators/jsonschema"
+)
+
+// tlsSchema mirrors the shape that breaks TCM: a scalar string field, an array
+// field and an object sub-tree, where the user leaves the YAML values empty
+// (null). cert-file is NOT nullable, exercising the scalar-null policy.
+const tlsSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"http": {
+			"type": "object",
+			"properties": {
+				"tls": {
+					"type": "object",
+					"properties": {
+						"cert-file": { "type": "string" },
+						"cipher-suites": {
+							"type": "array",
+							"items": { "type": "string" }
+						}
+					}
+				}
+			}
+		},
+		"instances": {
+			"type": "object",
+			"additionalProperties": { "type": "object" }
+		}
+	}
+}`
+
+// emptyValuesTree models the parsed config where every value is left empty:
+//
+//	http: { tls: { cert-file:, cipher-suites: } }
+//	instances: { inst-a: }
+func emptyValuesTree() *tree.Node {
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("http/tls/cert-file"), nil)
+	root.Set(keypath.NewKeyPath("http/tls/cipher-suites"), nil)
+	root.Set(keypath.NewKeyPath("instances/inst-a"), nil)
+
+	return root
+}
+
+func TestCoerce_ContainerNullsAlwaysFixed(t *testing.T) {
+	t.Parallel()
+
+	// Regardless of policy, an array-typed null becomes [] and an object-typed
+	// null becomes {}; only the scalar cert-file is policy-dependent. With the
+	// nullable variant below we isolate the container behaviour.
+	for _, policy := range []jsonschema.NullCoercion{
+		jsonschema.NullLeave, jsonschema.NullDrop, jsonschema.NullZero,
+	} {
+		validator, err := jsonschema.New([]byte(tlsSchema), jsonschema.WithNullCoercion(policy))
+		require.NoError(t, err)
+
+		root := tree.New()
+		root.Set(keypath.NewKeyPath("http/tls/cipher-suites"), nil)
+		root.Set(keypath.NewKeyPath("instances/inst-a"), nil)
+
+		errs := validator.Validate(root)
+		assert.Empty(t, errs, "container nulls must validate for policy %d", policy)
+	}
+}
+
+func TestCoerce_ScalarNull_Leave(t *testing.T) {
+	t.Parallel()
+
+	// NullLeave keeps cert-file null; a non-nullable string schema rejects it.
+	validator, err := jsonschema.New([]byte(tlsSchema), jsonschema.WithNullCoercion(jsonschema.NullLeave))
+	require.NoError(t, err)
+
+	errs := validator.Validate(emptyValuesTree())
+	require.NotEmpty(t, errs)
+}
+
+func TestCoerce_ScalarNull_Zero(t *testing.T) {
+	t.Parallel()
+
+	// NullZero turns cert-file into "", which satisfies the string schema.
+	validator, err := jsonschema.New([]byte(tlsSchema), jsonschema.WithNullCoercion(jsonschema.NullZero))
+	require.NoError(t, err)
+
+	errs := validator.Validate(emptyValuesTree())
+	assert.Empty(t, errs)
+}
+
+func TestCoerce_ScalarNull_Drop(t *testing.T) {
+	t.Parallel()
+
+	// NullDrop removes the empty cert-file key; the optional field is absent.
+	validator, err := jsonschema.New([]byte(tlsSchema), jsonschema.WithNullCoercion(jsonschema.NullDrop))
+	require.NoError(t, err)
+
+	errs := validator.Validate(emptyValuesTree())
+	assert.Empty(t, errs)
+}
+
+func TestCoerce_DefaultPolicyIsLeave(t *testing.T) {
+	t.Parallel()
+
+	// A validator created without an option uses DefaultNullCoercion (Leave).
+	assert.Equal(t, jsonschema.NullLeave, jsonschema.DefaultNullCoercion)
+
+	validator, err := jsonschema.New([]byte(tlsSchema))
+	require.NoError(t, err)
+
+	errs := validator.Validate(emptyValuesTree())
+	require.NotEmpty(t, errs)
+}
+
+func TestCoerce_NullableScalarStaysNull(t *testing.T) {
+	t.Parallel()
+
+	// A field declared nullable accepts null under every policy, and must not
+	// be coerced to "".
+	schema := `{
+		"type": "object",
+		"properties": {
+			"name": { "type": ["string", "null"] }
+		}
+	}`
+
+	for _, policy := range []jsonschema.NullCoercion{
+		jsonschema.NullLeave, jsonschema.NullDrop, jsonschema.NullZero,
+	} {
+		validator, err := jsonschema.New([]byte(schema), jsonschema.WithNullCoercion(policy))
+		require.NoError(t, err)
+
+		root := tree.New()
+		root.Set(keypath.NewKeyPath("name"), nil)
+
+		errs := validator.Validate(root)
+		assert.Empty(t, errs, "nullable scalar must validate for policy %d", policy)
+	}
+}
+
+// arrayNode builds an array node with the given children appended in order.
+func arrayNode(children ...*tree.Node) *tree.Node {
+	arr := tree.New()
+	arr.MarkArray()
+
+	for i, child := range children {
+		arr.SetChild(strconv.Itoa(i), child)
+	}
+
+	return arr
+}
+
+func TestCoerce_RefResolvesToObject(t *testing.T) {
+	t.Parallel()
+
+	// A property defined via $ref to an object schema: an empty value is
+	// coerced to {} after following ResolvedRef (effectiveSchema + schemaIsObject).
+	schema := `{
+		"type": "object",
+		"properties": { "inst": { "$ref": "#/$defs/Obj" } },
+		"$defs": { "Obj": { "type": "object", "properties": { "name": { "type": "string" } } } }
+	}`
+	validator, err := jsonschema.New([]byte(schema))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("inst"), nil)
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_ArrayItemsObject(t *testing.T) {
+	t.Parallel()
+
+	// A null element of an array-of-objects is coerced to {} via subschemaForItem.
+	schema := `{
+		"type": "object",
+		"properties": { "servers": { "type": "array", "items": { "type": "object" } } }
+	}`
+	validator, err := jsonschema.New([]byte(schema))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.SetChild("servers", arrayNode(tree.New()))
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_PrefixItemsZero(t *testing.T) {
+	t.Parallel()
+
+	// Tuple (prefixItems) elements left empty become typed zeros under NullZero,
+	// exercising subschemaForItem's prefix path and zeroForSchema string+integer.
+	schema := `{
+		"type": "object",
+		"properties": { "pair": { "type": "array", "prefixItems": [ { "type": "string" }, { "type": "integer" } ] } }
+	}`
+	validator, err := jsonschema.New([]byte(schema), jsonschema.WithNullCoercion(jsonschema.NullZero))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.SetChild("pair", arrayNode(tree.New(), tree.New()))
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_PatternProperties(t *testing.T) {
+	t.Parallel()
+
+	// An empty value under a patternProperties object schema becomes {}.
+	schema := `{ "type": "object", "patternProperties": { "^x-": { "type": "object" } } }`
+	validator, err := jsonschema.New([]byte(schema))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("x-meta"), nil)
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_CombinatorObjectAndArray(t *testing.T) {
+	t.Parallel()
+
+	// Type is reachable only through allOf/anyOf branches, exercising
+	// schemaIsObject/schemaIsArray's combinator descent.
+	schema := `{
+		"type": "object",
+		"properties": {
+			"obj": { "allOf": [ { "type": "object" } ] },
+			"arr": { "anyOf": [ { "type": "array", "items": { "type": "string" } } ] }
+		}
+	}`
+	validator, err := jsonschema.New([]byte(schema))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("obj"), nil)
+	root.Set(keypath.NewKeyPath("arr"), nil)
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_ZeroAllScalarTypes(t *testing.T) {
+	t.Parallel()
+
+	// NullZero produces the typed zero for every scalar kind.
+	schema := `{
+		"type": "object",
+		"properties": {
+			"b": { "type": "boolean" },
+			"n": { "type": "number" },
+			"i": { "type": "integer" },
+			"s": { "type": "string" }
+		}
+	}`
+	validator, err := jsonschema.New([]byte(schema), jsonschema.WithNullCoercion(jsonschema.NullZero))
+	require.NoError(t, err)
+
+	root := tree.New()
+	for _, key := range []string{"b", "n", "i", "s"} {
+		root.Set(keypath.NewKeyPath(key), nil)
+	}
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_DropInArrayFallsBackToNull(t *testing.T) {
+	t.Parallel()
+
+	// A scalar array element cannot be dropped (indices would shift), so NullDrop
+	// falls back to leaving it null — which a non-nullable item schema rejects.
+	schema := `{
+		"type": "object",
+		"properties": { "tags": { "type": "array", "items": { "type": "string" } } }
+	}`
+	validator, err := jsonschema.New([]byte(schema), jsonschema.WithNullCoercion(jsonschema.NullDrop))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.SetChild("tags", arrayNode(tree.New()))
+
+	require.NotEmpty(t, validator.Validate(root))
+}
+
+func TestCoerce_TypelessContainersByKeyword(t *testing.T) {
+	t.Parallel()
+
+	// Schemas that omit "type" but carry object/array keywords are still
+	// recognized (schemaIsObject via Properties, schemaIsArray via items).
+	schema := `{
+		"type": "object",
+		"properties": {
+			"obj": { "properties": { "a": { "type": "string" } } },
+			"arr": { "items": { "type": "string" } }
+		}
+	}`
+	validator, err := jsonschema.New([]byte(schema))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("obj"), nil)
+	root.Set(keypath.NewKeyPath("arr"), nil)
+
+	assert.Empty(t, validator.Validate(root))
+}
+
+func TestCoerce_UnconstrainedNullKeepsPolicy(t *testing.T) {
+	t.Parallel()
+
+	// A null at a path the schema does not describe has no subschema, so
+	// coercion falls through to the policy with a nil schema (subschemaForProperty
+	// and subschemaForItem returning nil, zeroForSchema(nil)).
+	schema := `{
+		"type": "object",
+		"properties": { "arr": { "type": "array" } }
+	}`
+	validator, err := jsonschema.New([]byte(schema), jsonschema.WithNullCoercion(jsonschema.NullZero))
+	require.NoError(t, err)
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("extra"), nil)  // no property/additionalProperties schema.
+	root.SetChild("arr", arrayNode(tree.New())) // array, no items schema.
+
+	assert.Empty(t, validator.Validate(root))
+}

--- a/validators/jsonschema/validator.go
+++ b/validators/jsonschema/validator.go
@@ -12,12 +12,24 @@ import (
 
 // Validator validates configuration against JSON Schema.
 type Validator struct {
-	schema   *jsonschema.Schema
-	compiler *jsonschema.Compiler
+	schema     *jsonschema.Schema
+	compiler   *jsonschema.Compiler
+	nullCoerce NullCoercion
+}
+
+// Option configures a Validator.
+type Option func(*Validator)
+
+// WithNullCoercion sets the scalar-null coercion policy for this validator,
+// overriding DefaultNullCoercion. See NullCoercion for details.
+func WithNullCoercion(policy NullCoercion) Option {
+	return func(v *Validator) {
+		v.nullCoerce = policy
+	}
 }
 
 // New creates a validator from schema bytes.
-func New(schemaData []byte) (*Validator, error) {
+func New(schemaData []byte, opts ...Option) (*Validator, error) {
 	compiler := jsonschema.NewCompiler()
 
 	schema, err := compiler.Compile(schemaData)
@@ -25,22 +37,29 @@ func New(schemaData []byte) (*Validator, error) {
 		return nil, fmt.Errorf("failed to compile JSON schema: %w", err)
 	}
 
-	return &Validator{schema: schema, compiler: compiler}, nil
+	v := &Validator{schema: schema, compiler: compiler, nullCoerce: DefaultNullCoercion}
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	return v, nil
 }
 
 // NewFromReader creates a validator from an io.Reader.
-func NewFromReader(r io.Reader) (*Validator, error) {
+func NewFromReader(r io.Reader, opts ...Option) (*Validator, error) {
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read schema: %w", err)
 	}
 
-	return New(data)
+	return New(data, opts...)
 }
 
 // Validate implements validator.Validator.
 func (v *Validator) Validate(root *tree.Node) []validator.ValidationError {
 	data := tree.ToAny(root)
+
+	data = coerceNulls(data, v.schema, v.nullCoerce)
 
 	result := v.schema.Validate(data)
 	if result.IsValid() {


### PR DESCRIPTION
An empty YAML value like `key:` parses to a null scalar leaf, and `tree.ToAny` (the converter used for JSON-Schema validation) turned any value-less, childless, non-array node into `map[string]any{}`. The empty value was therefore materialized as an object, so validation rejected it as "object but should be string/array" — the failure reported when running TCM against a config full of empty fields. `ToAny` now yields `nil` for such leaves, matching `nodeToValue`, and a schema-aware coercion pass rebuilds the empty shape the schema actually expects: `{}` where it wants an object and `[]` where it wants an array (always, resolving `$ref` and `allOf`/`anyOf`/`oneOf`). The genuinely ambiguous scalar case (string/number/bool) is governed by a configurable `jsonschema.NullCoercion` policy — `NullLeave` (default), `NullDrop` or `NullZero` — settable per-validator, per-build, or globally.

- tree: convert null scalar leaf to nil, not empty map
- jsonschema: schema-aware null coercion with configurable scalar policy
