### PR TITLE
tree: fix parsing `inline` structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+* Decoding a `tree.Value` into a struct now honors the yaml `inline`
+  tag option: a field tagged `,inline` that is anonymous or has no
+  explicit name is decoded from the parent map, flattening embedded
+  structs instead of looking them up under a nested key.
+
 * Schema-aware null coercion for JSON-Schema validation. Empty (null)
   values are coerced to `{}` where the schema expects an object and `[]`
   where it expects an array (resolving `$ref` and `allOf`/`anyOf`/`oneOf`).

--- a/internal/structtag/structtag.go
+++ b/internal/structtag/structtag.go
@@ -1,0 +1,38 @@
+// Package structtag parses the value of a single struct tag into its name
+// and options. It targets the near-universal `name,opt1,opt2` encoding used
+// by encoding/json, gopkg.in/yaml.v3 and most reflection-based decoders, so
+// it is not tied to any one tag key.
+package structtag
+
+import "strings"
+
+// Options is the set of comma-separated options that follow the name in a
+// struct tag value (for example "omitempty" or "inline").
+type Options map[string]struct{}
+
+// Has reports whether opt is present in the set.
+func (o Options) Has(opt string) bool {
+	_, ok := o[opt]
+	return ok
+}
+
+// Parse splits a struct tag value of the form "name,opt1,opt2" into the
+// name and the set of options. An empty name means the tag carried no
+// explicit name (for example ",inline" or the empty tag), leaving it to the
+// caller to fall back to the field name.
+func Parse(tag string) (string, Options) {
+	opts := Options{}
+
+	name := tag
+	if before, after, found := strings.Cut(tag, ","); found {
+		name = before
+
+		for opt := range strings.SplitSeq(after, ",") {
+			if opt != "" {
+				opts[opt] = struct{}{}
+			}
+		}
+	}
+
+	return name, opts
+}

--- a/internal/structtag/structtag_test.go
+++ b/internal/structtag/structtag_test.go
@@ -1,0 +1,53 @@
+package structtag_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tarantool/go-config/internal/structtag"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		tag      string
+		wantName string
+		wantOpts []string
+	}{
+		{name: "empty", tag: "", wantName: "", wantOpts: nil},
+		{name: "name only", tag: "id", wantName: "id", wantOpts: nil},
+		{name: "name and option", tag: "id,omitempty", wantName: "id", wantOpts: []string{"omitempty"}},
+		{name: "option only", tag: ",inline", wantName: "", wantOpts: []string{"inline"}},
+		{
+			name: "multiple options", tag: "id,omitempty,inline",
+			wantName: "id", wantOpts: []string{"omitempty", "inline"},
+		},
+		{name: "trailing comma", tag: "id,", wantName: "id", wantOpts: nil},
+		{name: "empty options between commas", tag: "id,,inline", wantName: "id", wantOpts: []string{"inline"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			name, opts := structtag.Parse(tt.tag)
+			assert.Equal(t, tt.wantName, name)
+
+			for _, opt := range tt.wantOpts {
+				assert.True(t, opts.Has(opt), "expected option %q", opt)
+			}
+
+			assert.Len(t, opts, len(tt.wantOpts))
+		})
+	}
+}
+
+func TestOptions_Has_Absent(t *testing.T) {
+	t.Parallel()
+
+	_, opts := structtag.Parse("id,omitempty")
+	assert.False(t, opts.Has("inline"))
+}

--- a/tree/value.go
+++ b/tree/value.go
@@ -613,20 +613,27 @@ func decodeStruct(src any, dst reflect.Value) error {
 			continue
 		}
 
-		// Get yaml tag.
-		tag := field.Tag.Get("yaml")
-		if tag == "" {
-			// Fallback to field name.
-			tag = field.Name
-		} else {
-			// Handle yaml tag options like "omitempty".
-			if comma := strings.Index(tag, ","); comma != -1 {
-				tag = tag[:comma]
+		name, opts := parseYAMLTag(field.Tag.Get("yaml"))
+
+		// Inline (embedded) struct: decode the same source map into it
+		// so its fields are looked up at the current level rather than
+		// under a key.
+		if opts["inline"] && (field.Anonymous || name == "") {
+			err := decode(src, dst.Field(i))
+			if err != nil {
+				return fmt.Errorf("inline field %q: %w", field.Name, err)
 			}
+
+			continue
+		}
+
+		if name == "" {
+			// Fallback to field name.
+			name = field.Name
 		}
 
 		// Look up key in source map.
-		key := reflect.ValueOf(tag)
+		key := reflect.ValueOf(name)
 
 		val := srcVal.MapIndex(key)
 		if !val.IsValid() {
@@ -642,6 +649,26 @@ func decodeStruct(src any, dst reflect.Value) error {
 	}
 
 	return nil
+}
+
+// parseYAMLTag splits a yaml struct tag into the field name and the
+// set of options that follow it. An empty name means the tag carried
+// no explicit name.
+func parseYAMLTag(tag string) (string, map[string]bool) {
+	opts := map[string]bool{}
+
+	name := tag
+	if before, after, found := strings.Cut(tag, ","); found {
+		name = before
+
+		for opt := range strings.SplitSeq(after, ",") {
+			if opt != "" {
+				opts[opt] = true
+			}
+		}
+	}
+
+	return name, opts
 }
 
 // decodePtr converts src to pointer.

--- a/tree/value.go
+++ b/tree/value.go
@@ -5,9 +5,9 @@ import (
 	"math"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
+	"github.com/tarantool/go-config/internal/structtag"
 	"github.com/tarantool/go-config/keypath"
 	"github.com/tarantool/go-config/meta"
 	"github.com/tarantool/go-config/value"
@@ -613,18 +613,20 @@ func decodeStruct(src any, dst reflect.Value) error {
 			continue
 		}
 
-		name, opts := parseYAMLTag(field.Tag.Get("yaml"))
+		name, opts := structtag.Parse(field.Tag.Get("yaml"))
 
-		// Inline (embedded) struct: decode the same source map into it
-		// so its fields are looked up at the current level rather than
-		// under a key.
-		if opts["inline"] && (field.Anonymous || name == "") {
-			err := decode(src, dst.Field(i))
+		// Inline field: an anonymous or explicitly-unnamed field tagged
+		// `,inline` is flattened, i.e. its own fields are looked up in the
+		// parent map at the current level rather than under a key.
+		if opts.Has("inline") && (field.Anonymous || name == "") {
+			handled, err := decodeInlineField(src, dst.Field(i), field.Name)
 			if err != nil {
-				return fmt.Errorf("inline field %q: %w", field.Name, err)
+				return err
 			}
 
-			continue
+			if handled {
+				continue
+			}
 		}
 
 		if name == "" {
@@ -651,24 +653,30 @@ func decodeStruct(src any, dst reflect.Value) error {
 	return nil
 }
 
-// parseYAMLTag splits a yaml struct tag into the field name and the
-// set of options that follow it. An empty name means the tag carried
-// no explicit name.
-func parseYAMLTag(tag string) (string, map[string]bool) {
-	opts := map[string]bool{}
-
-	name := tag
-	if before, after, found := strings.Cut(tag, ","); found {
-		name = before
-
-		for opt := range strings.SplitSeq(after, ",") {
-			if opt != "" {
-				opts[opt] = true
-			}
-		}
+// decodeInlineField flattens a field tagged `,inline` by decoding the parent
+// source map into it, and reports whether it consumed the field.
+//
+// Only structs and pointers-to-struct flatten. A map tagged `,inline` (the
+// go-yaml catch-all) is deliberately not supported: decoding the whole parent
+// map into it would let it swallow keys that sibling fields already own, and
+// implementing it correctly requires assigning only the leftover keys. Such a
+// field is left unhandled so the caller falls back to a normal by-name lookup.
+func decodeInlineField(src any, fieldVal reflect.Value, fieldName string) (bool, error) {
+	elemType := fieldVal.Type()
+	if elemType.Kind() == reflect.Pointer {
+		elemType = elemType.Elem()
 	}
 
-	return name, opts
+	if elemType.Kind() != reflect.Struct {
+		return false, nil
+	}
+
+	err := decode(src, fieldVal)
+	if err != nil {
+		return true, fmt.Errorf("inline field %q: %w", fieldName, err)
+	}
+
+	return true, nil
 }
 
 // decodePtr converts src to pointer.

--- a/tree/value_test.go
+++ b/tree/value_test.go
@@ -1850,6 +1850,32 @@ func TestValue_Get_StructInlineEmbeddedPointer(t *testing.T) {
 	assert.True(t, cfg.Enabled)
 }
 
+func TestValue_Get_StructInlineMapNotSwallowed(t *testing.T) {
+	t.Parallel()
+
+	// A map tagged `,inline` is not a supported catch-all: it must not
+	// swallow keys owned by sibling fields. It falls through to a normal
+	// by-name lookup ("Rest"), which is absent here, leaving it nil.
+	type Config struct {
+		Enabled bool           `yaml:"enabled"`
+		Rest    map[string]any `yaml:",inline"`
+	}
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("cfg/enabled"), true)
+	root.Set(keypath.NewKeyPath("cfg/extra"), 1)
+
+	node := root.Get(keypath.NewKeyPath("cfg"))
+	val := tree.NewValue(node, keypath.NewKeyPath("cfg"))
+
+	var cfg Config
+
+	err := val.Get(&cfg)
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+	assert.NotContains(t, cfg.Rest, "enabled")
+}
+
 // An array-marked leaf that carries its slice directly in Value (no child
 // nodes) must not be flattened to an empty slice: handling the array branch
 // before the leaf check would otherwise drop the data.

--- a/tree/value_test.go
+++ b/tree/value_test.go
@@ -1760,6 +1760,96 @@ func TestValue_Get_EmptyArrayNode_AsAnyIsSlice(t *testing.T) {
 	assert.Empty(t, slice)
 }
 
+func TestValue_Get_StructInlineEmbedded(t *testing.T) {
+	t.Parallel()
+
+	type Base struct {
+		ID   int    `yaml:"id"`
+		Name string `yaml:"name"`
+	}
+
+	type Config struct {
+		Base `yaml:",inline"`
+
+		Enabled bool `yaml:"enabled"`
+	}
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("cfg/id"), 7)
+	root.Set(keypath.NewKeyPath("cfg/name"), "svc")
+	root.Set(keypath.NewKeyPath("cfg/enabled"), true)
+
+	node := root.Get(keypath.NewKeyPath("cfg"))
+	val := tree.NewValue(node, keypath.NewKeyPath("cfg"))
+
+	var cfg Config
+
+	err := val.Get(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 7, cfg.ID)
+	assert.Equal(t, "svc", cfg.Name)
+	assert.True(t, cfg.Enabled)
+}
+
+func TestValue_Get_StructInlineNamedField(t *testing.T) {
+	t.Parallel()
+
+	type Base struct {
+		ID   int    `yaml:"id"`
+		Name string `yaml:"name"`
+	}
+
+	type Config struct {
+		Base    Base `yaml:",inline"`
+		Enabled bool `yaml:"enabled"`
+	}
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("cfg/id"), 3)
+	root.Set(keypath.NewKeyPath("cfg/name"), "inline")
+	root.Set(keypath.NewKeyPath("cfg/enabled"), true)
+
+	node := root.Get(keypath.NewKeyPath("cfg"))
+	val := tree.NewValue(node, keypath.NewKeyPath("cfg"))
+
+	var cfg Config
+
+	err := val.Get(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 3, cfg.Base.ID)
+	assert.Equal(t, "inline", cfg.Base.Name)
+	assert.True(t, cfg.Enabled)
+}
+
+func TestValue_Get_StructInlineEmbeddedPointer(t *testing.T) {
+	t.Parallel()
+
+	type Base struct {
+		ID int `yaml:"id"`
+	}
+
+	type Config struct {
+		*Base `yaml:",inline"`
+
+		Enabled bool `yaml:"enabled"`
+	}
+
+	root := tree.New()
+	root.Set(keypath.NewKeyPath("cfg/id"), 42)
+	root.Set(keypath.NewKeyPath("cfg/enabled"), true)
+
+	node := root.Get(keypath.NewKeyPath("cfg"))
+	val := tree.NewValue(node, keypath.NewKeyPath("cfg"))
+
+	var cfg Config
+
+	err := val.Get(&cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Base)
+	assert.Equal(t, 42, cfg.ID)
+	assert.True(t, cfg.Enabled)
+}
+
 // An array-marked leaf that carries its slice directly in Value (no child
 // nodes) must not be flattened to an empty slice: handling the array branch
 // before the leaf check would otherwise drop the data.


### PR DESCRIPTION
The yaml `inline` option is now recognized: a field tagged ',inline`, which is anonymous or does not have an explicit name.

