### PR TITLE
jsonschema: schema-aware scalar coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `Builder.WithJSONSchema` options or `tarantool.Builder.WithNullCoercion`,
   or globally via `jsonschema.DefaultNullCoercion`.
 
+* Schema-aware scalar coercion for JSON-Schema validation. When the schema
+  at a location expects a scalar type (`boolean`, `integer` or `number`)
+  but the value is a string — the shape environment-variable collectors
+  produce — the string is parsed into that type before validation
+  (resolving `$ref` and combinators). A string is coerced only when the
+  schema does not also permit `string` (a `["boolean", "string"]` union
+  keeps the string) and only when it parses; an unparsable string is left
+  unchanged so validation still reports a type error. Like null coercion
+  this rewrites the validation copy only, not the config tree. This lets a
+  strict `{"type": "boolean"}` field accept `MYAPP_FLAG=true` from the env
+  collector without widening the schema to a string union.
+
 ### Changed
 
 ### Fixed

--- a/validators/jsonschema/coerce.go
+++ b/validators/jsonschema/coerce.go
@@ -3,6 +3,7 @@ package jsonschema
 import (
 	"regexp"
 	"slices"
+	"strconv"
 
 	"github.com/kaptinlin/jsonschema"
 )
@@ -80,6 +81,74 @@ func coerceNulls(data any, schema *jsonschema.Schema, policy NullCoercion) any {
 	default:
 		return data
 	}
+}
+
+// coerceScalars walks data alongside the schema and, where the schema at a
+// location expects a scalar type (boolean, integer or number) but the value is
+// a string, parses the string into that type. This is the shape produced by
+// collectors that carry only strings — most importantly environment variables:
+// LUAMERGE_DEBUG=true arrives as the string "true", which would otherwise be
+// rejected by a strict `{"type": "boolean"}` schema.
+//
+// A string is coerced only when the schema does not also permit "string" (a
+// union like `["boolean", "string"]` keeps the string as-is) and only when it
+// parses; an unparsable string is left unchanged so the validator reports a
+// proper type error rather than the coercion masking it. The (possibly
+// mutated) data is returned.
+//
+// Like coerceNulls, this rewrites the copy used for validation only; it does
+// not alter the configuration tree, whose typed decode handles string scalars
+// on its own.
+func coerceScalars(data any, schema *jsonschema.Schema) any {
+	schema = effectiveSchema(schema)
+
+	switch typed := data.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = coerceScalars(child, subschemaForProperty(schema, key))
+		}
+
+		return typed
+	case []any:
+		for i, item := range typed {
+			typed[i] = coerceScalars(item, subschemaForItem(schema, i))
+		}
+
+		return typed
+	case string:
+		return coerceScalarString(typed, schema)
+	default:
+		return data
+	}
+}
+
+// coerceScalarString parses str into the scalar type the schema demands, unless
+// that type is (or includes) string. On any parse failure the original string
+// is returned unchanged.
+func coerceScalarString(str string, schema *jsonschema.Schema) any {
+	if schema == nil || schemaAllows(schema, "string") {
+		return str
+	}
+
+	switch {
+	case schemaAllows(schema, "boolean"):
+		parsed, err := strconv.ParseBool(str)
+		if err == nil {
+			return parsed
+		}
+	case schemaAllows(schema, "integer"):
+		parsed, err := strconv.ParseInt(str, 10, 64)
+		if err == nil {
+			return parsed
+		}
+	case schemaAllows(schema, "number"):
+		parsed, err := strconv.ParseFloat(str, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+
+	return str
 }
 
 // coerceNull resolves a single null value against its schema.

--- a/validators/jsonschema/coerce_scalar_test.go
+++ b/validators/jsonschema/coerce_scalar_test.go
@@ -1,0 +1,130 @@
+package jsonschema_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/validators/jsonschema"
+)
+
+// scalarSchema mirrors a config with strict scalar types plus a union field.
+// Environment-variable collectors deliver every value as a string, so these
+// strict types would reject env overrides without scalar coercion.
+const scalarSchema = `{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"type": "object",
+	"properties": {
+		"flag": { "type": "boolean" },
+		"count": { "type": "integer" },
+		"ratio": { "type": "number" },
+		"name": { "type": "string" },
+		"either": { "type": ["boolean", "string"] },
+		"nested": {
+			"type": "object",
+			"properties": {
+				"on": { "type": "boolean" }
+			}
+		},
+		"flags": {
+			"type": "array",
+			"items": { "type": "boolean" }
+		}
+	}
+}`
+
+// stringTree builds a config tree where key holds the given string value, the
+// shape an environment-variable collector produces.
+func stringTree(key, value string) *tree.Node {
+	root := tree.New()
+	root.Set(keypath.NewKeyPath(key), value)
+
+	return root
+}
+
+// leaf builds a scalar leaf node holding the given string value.
+func leaf(value string) *tree.Node {
+	node := tree.New()
+
+	node.Value = value
+
+	return node
+}
+
+func TestCoerceScalars_BoolStringForms(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	// Every string strconv.ParseBool accepts must validate against "boolean".
+	for _, form := range []string{"true", "false", "1", "0", "t", "T", "f", "F", "TRUE", "False"} {
+		errs := validator.Validate(stringTree("flag", form))
+		assert.Emptyf(t, errs, "flag=%q should coerce to boolean and validate", form)
+	}
+}
+
+func TestCoerceScalars_IntegerAndNumber(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	assert.Empty(t, validator.Validate(stringTree("count", "123")), "integer string should validate")
+	assert.Empty(t, validator.Validate(stringTree("ratio", "1.5")), "number string should validate")
+}
+
+func TestCoerceScalars_UnparseableStringStillFails(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	// "yes" is not accepted by strconv.ParseBool, so it is left as a string and
+	// the strict boolean type rejects it.
+	assert.NotEmpty(t, validator.Validate(stringTree("flag", "yes")),
+		"unparsable bool string must not be coerced and must fail validation")
+	assert.NotEmpty(t, validator.Validate(stringTree("count", "abc")),
+		"unparsable integer string must fail validation")
+}
+
+func TestCoerceScalars_StringFieldUntouched(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	// A genuine string field accepts any string; it must never be coerced.
+	assert.Empty(t, validator.Validate(stringTree("name", "true")),
+		"string field must accept a string value unchanged")
+}
+
+func TestCoerceScalars_UnionKeepsString(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	// A ["boolean", "string"] union already permits the string, so no coercion
+	// is needed and the string form validates as-is.
+	assert.Empty(t, validator.Validate(stringTree("either", "true")),
+		"union type must accept the string form without coercion")
+}
+
+func TestCoerceScalars_NestedAndArrayItems(t *testing.T) {
+	t.Parallel()
+
+	validator, err := jsonschema.New([]byte(scalarSchema))
+	require.NoError(t, err)
+
+	assert.Empty(t, validator.Validate(stringTree("nested/on", "true")),
+		"nested object scalar string should coerce")
+
+	root := tree.New()
+	root.SetChild("flags", arrayNode(leaf("true"), leaf("false")))
+
+	assert.Empty(t, validator.Validate(root), "array item scalar strings should coerce")
+}

--- a/validators/jsonschema/validator.go
+++ b/validators/jsonschema/validator.go
@@ -60,6 +60,7 @@ func (v *Validator) Validate(root *tree.Node) []validator.ValidationError {
 	data := tree.ToAny(root)
 
 	data = coerceNulls(data, v.schema, v.nullCoerce)
+	data = coerceScalars(data, v.schema)
 
 	result := v.schema.Validate(data)
 	if result.IsValid() {


### PR DESCRIPTION
Environment-variable collectors deliver every value as a string, so a strict scalar schema such as `{"type": "boolean"}` rejects an override like `MYAPP_FLAG=true` even though the typed decode would accept it. Consumers had to widen every env-overridable scalar to a `["boolean", "string"]` union to work around this.

Add `coerceScalars`, a sibling of `coerceNulls`, that walks the validation data alongside the schema and parses a string into the scalar type the schema demands (boolean, integer or number), resolving `$ref` and combinators via the existing helpers. A string is coerced only when the schema does not also permit "string" and only when it parses; an unparseable string is left unchanged so validation still reports a type error. Like `null` coercion it rewrites the validation copy only, never the config tree, whose decode already handles string scalars.

Wire it into `Validator.Validate` after null coercion and cover it with tests for the bool string forms, integer/number strings, unparseable strings, genuine string fields, unions, and nested/array locations.