### PR TITLE
ci: update actions to their latest versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,8 +17,8 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -40,7 +40,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: install codespell
         run:  pip3 install codespell==${CODESPELL_VERSION}
@@ -55,8 +55,8 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/sync-tarantool-schemas.yaml
+++ b/.github/workflows/sync-tarantool-schemas.yaml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        golang: ["1.24", "stable"]
+        golang: ["1.25", "stable"]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.golang }}
+          go-version-file: go.mod
 
       - name: run tests, collect code coverage data and send to Coveralls
         env:
@@ -62,6 +62,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: ${{ matrix.golang }}
+          go-version-file: go.mod
       - name: run benchmarks
         run: make bench

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,8 +20,8 @@ jobs:
         golang: ["1.24", "stable"]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.golang }}
 
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.golang }}
 
@@ -59,8 +59,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.golang }}
       - name: run benchmarks

--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -27,9 +27,9 @@ jobs:
        github.event.pull_request.head.repo.full_name != github.repository)
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
actions/checkout v4 and actions/setup-go v5 run on Node 20, which GitHub has deprecated and now forces onto Node 24, so every job logged a warning.

Moves checkout and setup-go to v7 in every workflow, including vulncheck.yaml, which was already on v6, so all workflows agree on one version. golangci-lint-action and peter-evans/create-pull-request are already on their latest majors and are unchanged, as is tarantool/actions/report-job-status, which is tracked at master.