### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ no longer turns null leaves into empty maps.
 * Embedded Tarantool JSON Schemas now include versions 3.6.4, 3.7.1, and
   3.8.0 (#83).
 
+### Changed
+
+* Updated the `github.com/tarantool/go-storage` dependency from a
+  development pseudo-version to the v1.6.1 release (#86).
+
 ### Fixed
 
 * `tree.ToAny` no longer converts a null scalar leaf into an empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,25 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v1.5.0] - 2026-08-05
+
+The release adds schema-aware coercion for JSON-Schema validation: null
+values are coerced to the container shape the schema expects, and string
+scalars from environment collectors are parsed into the expected
+boolean/integer/number types, with a configurable `NullCoercion` policy.
+Struct decoding now honors the yaml `inline` tag option, and `tree.ToAny`
+no longer turns null leaves into empty maps.
+
+### Added
+
 * Decoding a `tree.Value` into a struct now honors the yaml `inline`
   tag option: a field tagged `,inline` that is anonymous or has no
   explicit name is decoded from the parent map, flattening embedded
-  structs instead of looking them up under a nested key.
+  structs instead of looking them up under a nested key (#82).
 
 * Schema-aware null coercion for JSON-Schema validation. Empty (null)
   values are coerced to `{}` where the schema expects an object and `[]`
@@ -23,7 +38,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   (treat empty as unset) or `NullZero` (typed zero value) — set
   per-validator via `jsonschema.WithNullCoercion`, per-build via
   `Builder.WithJSONSchema` options or `tarantool.Builder.WithNullCoercion`,
-  or globally via `jsonschema.DefaultNullCoercion`.
+  or globally via `jsonschema.DefaultNullCoercion` (#81).
 
 * Schema-aware scalar coercion for JSON-Schema validation. When the schema
   at a location expects a scalar type (`boolean`, `integer` or `number`)
@@ -35,9 +50,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   unchanged so validation still reports a type error. Like null coercion
   this rewrites the validation copy only, not the config tree. This lets a
   strict `{"type": "boolean"}` field accept `MYAPP_FLAG=true` from the env
-  collector without widening the schema to a string union.
+  collector without widening the schema to a string union (#84).
 
-### Changed
+* Embedded Tarantool JSON Schemas now include versions 3.6.4, 3.7.1, and
+  3.8.0 (#83).
 
 ### Fixed
 
@@ -46,7 +62,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   leaf, so it was materialized as an object and JSON-Schema validation
   rejected it as `object but should be string/array`. It now yields
   `nil`, matching `nodeToValue`. Empty mappings (`{}`) and empty
-  sequences (`[]`) keep their respective shapes.
+  sequences (`[]`) keep their respective shapes (#81).
 
 ## [v1.4.0] - 2026-06-09
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/kaptinlin/jsonschema v0.6.7
 	github.com/stretchr/testify v1.11.1
-	github.com/tarantool/go-storage v1.5.1-0.20260527151257-3ae3f3f74d2b
+	github.com/tarantool/go-storage v1.6.1
 	go.etcd.io/etcd/client/v3 v3.6.11
 	go.yaml.in/yaml/v3 v3.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/tarantool/go-iproto v1.1.0 h1:HULVOIHsiehI+FnHfM7wMDntuzUddO09DKqu2Wn
 github.com/tarantool/go-iproto v1.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/tarantool/go-option v1.0.0 h1:+Etw0i3TjsXvADTo5rfZNCfsXe3BfHOs+iVfIrl0Nlo=
 github.com/tarantool/go-option v1.0.0/go.mod h1:lXzzeZtL+rPUtLOCDP6ny3FemFBjruG9aHKzNN2bS08=
-github.com/tarantool/go-storage v1.5.1-0.20260527151257-3ae3f3f74d2b h1:rWMPqKGIz8QFgds0140o+dMoGTVn8KLrWR79Fem9U7c=
-github.com/tarantool/go-storage v1.5.1-0.20260527151257-3ae3f3f74d2b/go.mod h1:B1xI1ibaYZdV9ZJVa9mxhwoW/LMWytYw1FeOBDPjN1Y=
+github.com/tarantool/go-storage v1.6.1 h1:9QwORMa5NpgE2c+RcvLKcAtOAWAKFb710ZPBErwFPvA=
+github.com/tarantool/go-storage v1.6.1/go.mod h1:B1xI1ibaYZdV9ZJVa9mxhwoW/LMWytYw1FeOBDPjN1Y=
 github.com/tarantool/go-tarantool/v2 v2.4.1 h1:Bk9mh+gMPVmHTSefHvVBpEkf6P2UZA/8xa5kqgyQtyo=
 github.com/tarantool/go-tarantool/v2 v2.4.1/go.mod h1:MTbhdjFc3Jl63Lgi/UJr5D+QbT+QegqOzsNJGmaw7VM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=


### PR DESCRIPTION
The release adds schema-aware coercion for JSON-Schema validation: null values are coerced to the container shape the schema expects, and string scalars from environment collectors are parsed into the expected boolean/integer/number types, with a configurable `NullCoercion` policy. Struct decoding now honors the yaml `inline` tag option, and `tree.ToAny` no longer turns null leaves into empty maps.

### Added

* Decoding a `tree.Value` into a struct now honors the yaml `inline` tag option: a field tagged `,inline` that is anonymous or has no explicit name is decoded from the parent map, flattening embedded structs instead of looking them up under a nested key (#82).

* Schema-aware null coercion for JSON-Schema validation. Empty (null) values are coerced to `{}` where the schema expects an object and `[]` where it expects an array (resolving `$ref` and `allOf`/`anyOf`/`oneOf`). The ambiguous scalar case is governed by a configurable `jsonschema.NullCoercion` policy — `NullLeave` (default), `NullDrop` (treat empty as unset) or `NullZero` (typed zero value) — set per-validator via `jsonschema.WithNullCoercion`, per-build via `Builder.WithJSONSchema` options or `tarantool.Builder.WithNullCoercion`, or globally via `jsonschema.DefaultNullCoercion` (#81).

* Schema-aware scalar coercion for JSON-Schema validation. When the schema at a location expects a scalar type (`boolean`, `integer` or `number`) but the value is a string — the shape environment-variable collectors produce — the string is parsed into that type before validation (resolving `$ref` and combinators). A string is coerced only when the schema does not also permit `string` (a `["boolean", "string"]` union keeps the string) and only when it parses; an unparsable string is left unchanged so validation still reports a type error. Like null coercion this rewrites the validation copy only, not the config tree. This lets a strict `{"type": "boolean"}` field accept `MYAPP_FLAG=true` from the env collector without widening the schema to a string union (#84).

* Embedded Tarantool JSON Schemas now include versions 3.6.4, 3.7.1, and 3.8.0 (#83).

### Changed

* Updated the `github.com/tarantool/go-storage` dependency from a development pseudo-version to the v1.6.1 release (#86).

### Fixed

* `tree.ToAny` no longer converts a null scalar leaf into an empty `map[string]any{}`. An empty YAML value (e.g. `key:`) parses to such a leaf, so it was materialized as an object and JSON-Schema validation rejected it as `object but should be string/array`. It now yields `nil`, matching `nodeToValue`. Empty mappings (`{}`) and empty sequences (`[]`) keep their respective shapes (#81).