### PR TITLE
Release v2.0.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters:
             - $gostd
             - "github.com/stretchr/testify"
             - "go.yaml.in/yaml/v3"
-            - "github.com/tarantool/go-config"
+            - "github.com/tarantool/go-config/v2"
             - "github.com/tarantool/go-storage"
             - "github.com/kaptinlin/jsonschema"
             - "go.etcd.io/etcd"
@@ -80,7 +80,7 @@ linters:
           allow:
             - $gostd
             - "github.com/stretchr/testify"
-            - "github.com/tarantool/go-config"
+            - "github.com/tarantool/go-config/v2"
             - "github.com/tarantool/go-storage"
             - "github.com/kaptinlin/jsonschema"
             - "go.etcd.io/etcd"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+## [v2.0.1] - 2026-08-25
+
+This release bumps the project path to `github.com/tarantool/go-config/v2`.
+
+### Changed
+
+* Changed project path to `github.com/tarantool/go-config/v2`.
+
 ## [v2.0.0] - 2026-08-25
 
 This release migrates the storage integration from

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ merging and resolves effective configuration for any entity in the hierarchy.
 ### Installation
 
 ```bash
-go get github.com/tarantool/go-config
+go get github.com/tarantool/go-config/v2
 ```
 
 ### Quick Start
@@ -66,8 +66,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/tarantool/go-config"
-    "github.com/tarantool/go-config/collectors"
+    "github.com/tarantool/go-config/v2"
+    "github.com/tarantool/go-config/v2/collectors"
 )
 
 func main() {
@@ -108,8 +108,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/tarantool/go-config"
-    "github.com/tarantool/go-config/collectors"
+    "github.com/tarantool/go-config/v2"
+    "github.com/tarantool/go-config/v2/collectors"
 )
 
 func main() {
@@ -177,7 +177,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/tarantool/go-config/tarantool"
+    "github.com/tarantool/go-config/v2/tarantool"
 )
 
 func main() {
@@ -407,10 +407,10 @@ a pull request.
 This project is licensed under the BSD 2-Clause License – see the
 [LICENSE](LICENSE) file for details.
 
-[godoc-badge]: https://pkg.go.dev/badge/github.com/tarantool/go-config.svg
-[godoc-url]: https://pkg.go.dev/github.com/tarantool/go-config
-[actions-badge]: https://github.com/tarantool/go-config/actions/workflows/testing.yml/badge.svg
-[actions-url]: https://github.com/tarantool/go-config/actions/workflows/testing.yml
+[godoc-badge]: https://pkg.go.dev/badge/github.com/tarantool/go-config/v2.svg
+[godoc-url]: https://pkg.go.dev/github.com/tarantool/go-config/v2
+[actions-badge]: https://github.com/tarantool/go-config/v2/actions/workflows/testing.yml/badge.svg
+[actions-url]: https://github.com/tarantool/go-config/v2/actions/workflows/testing.yml
 [coverage-badge]: https://coveralls.io/repos/github/tarantool/go-config/badge.svg?branch=master
 [coverage-url]: https://coveralls.io/github/tarantool/go-config?branch=master
 [telegram-badge]: https://img.shields.io/badge/Telegram-join%20chat-blue.svg

--- a/builder.go
+++ b/builder.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"sync"
 
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 // DefaultsType is a wrapper for default values in inheritance zones.

--- a/builder_test.go
+++ b/builder_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 func TestConfigBuilder_PortOverride(t *testing.T) {

--- a/builder_validation_test.go
+++ b/builder_validation_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 // mockValidator is a test validator that returns predefined errors.

--- a/collectors/directory.go
+++ b/collectors/directory.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Directory implements config.Collector and config.MultiCollector for reading

--- a/collectors/directory_test.go
+++ b/collectors/directory_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestNewDirectory(t *testing.T) {

--- a/collectors/env.go
+++ b/collectors/env.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/internal/environ"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/internal/environ"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Env reads configuration data from environment variables.

--- a/collectors/env_test.go
+++ b/collectors/env_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestNewEnv(t *testing.T) {

--- a/collectors/errors_test.go
+++ b/collectors/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 var errFormatParseTestSentinel = errors.New("unexpected token")

--- a/collectors/format.go
+++ b/collectors/format.go
@@ -3,7 +3,7 @@ package collectors
 import (
 	"io"
 
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Format represents way to convert some data into the tree.Node.

--- a/collectors/map.go
+++ b/collectors/map.go
@@ -3,8 +3,8 @@ package collectors
 import (
 	"context"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Map reads configuration data from a map.

--- a/collectors/map_test.go
+++ b/collectors/map_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestNewMap(t *testing.T) {

--- a/collectors/mock.go
+++ b/collectors/mock.go
@@ -3,8 +3,8 @@ package collectors
 import (
 	"context"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Mock is a testing collector that returns a predefined set of values.

--- a/collectors/mock_test.go
+++ b/collectors/mock_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestNewMock(t *testing.T) {

--- a/collectors/source.go
+++ b/collectors/source.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // DataSource represent data source.

--- a/collectors/source_test.go
+++ b/collectors/source_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 func TestNewFile(t *testing.T) {

--- a/collectors/storage.go
+++ b/collectors/storage.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 	"github.com/tarantool/go-storage/v2/integrity"
 )
 

--- a/collectors/storage_source.go
+++ b/collectors/storage_source.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/v2"
 	storage "github.com/tarantool/go-storage/v2"
 	"github.com/tarantool/go-storage/v2/crypto"
 	"github.com/tarantool/go-storage/v2/hasher"

--- a/collectors/storage_source_test.go
+++ b/collectors/storage_source_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 var errTestTxFailure = errors.New("tx failed")

--- a/collectors/storage_test.go
+++ b/collectors/storage_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestNewStorage(t *testing.T) {

--- a/collectors/struct.go
+++ b/collectors/struct.go
@@ -8,8 +8,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Struct reads configuration data from a Go struct using reflection.

--- a/collectors/struct_test.go
+++ b/collectors/struct_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 type structLog struct {

--- a/collectors/tree_walk.go
+++ b/collectors/tree_walk.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"slices"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func flattenMapIntoTree(node *tree.Node, prefix config.KeyPath, m map[string]any, keepOrder bool) {

--- a/collectors/yaml.go
+++ b/collectors/yaml.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tree"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/collectors/yaml_test.go
+++ b/collectors/yaml_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 //go:embed testdata/config.yaml

--- a/config.go
+++ b/config.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 // MergerContext holds state for merging a single collector's values.

--- a/config_coverage_test.go
+++ b/config_coverage_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 // alwaysFailingValidator that always fails.

--- a/config_test.go
+++ b/config_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/meta"
 )
 
 func TestConfig_Stat_ExistingKey(t *testing.T) {

--- a/defaultmerger.go
+++ b/defaultmerger.go
@@ -3,8 +3,8 @@ package config
 import (
 	"slices"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // defaultMergerContext implements MergerContext.

--- a/defaultmerger_test.go
+++ b/defaultmerger_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestDefaultMerger_CreateContext(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/v2"
 )
 
 type customError string

--- a/example_builder_test.go
+++ b/example_builder_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 // Example_multipleCollectorPriority demonstrates priority-based merging

--- a/example_collectors_test.go
+++ b/example_collectors_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 // Example_envCollector demonstrates the Env collector which reads

--- a/example_config_test.go
+++ b/example_config_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 // Example_basicGetAndLookup demonstrates the core Config API methods:

--- a/example_inheritance_test.go
+++ b/example_inheritance_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 // Example_inheritanceBasic demonstrates hierarchical configuration inheritance.

--- a/example_merger_test.go
+++ b/example_merger_test.go
@@ -9,9 +9,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Example_validatingMerger demonstrates a custom merger that validates

--- a/example_storage_test.go
+++ b/example_storage_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 // Example_storageCollector demonstrates reading multiple configuration

--- a/example_validation_test.go
+++ b/example_validation_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 // Example_validation demonstrates JSON Schema validation of configuration.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tarantool/go-config
+module github.com/tarantool/go-config/v2
 
 go 1.26.5
 
@@ -86,3 +86,5 @@ exclude (
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215
 )
+
+retract v2.0.0 // Broken release.

--- a/inheritance.go
+++ b/inheritance.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 const segmentsPerLevel = 2

--- a/inheritance_internal_test.go
+++ b/inheritance_internal_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestMatchHierarchy(t *testing.T) {

--- a/inheritance_test.go
+++ b/inheritance_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 func TestWithInheritance_BasicInheritance(t *testing.T) {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -6,7 +6,7 @@ import (
 
 	etcdtest "github.com/tarantool/go-storage/v2/test_helpers/etcd"
 
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 // TestMain owns the lifecycle of the embedded etcd shared across the

--- a/integration/storage_integration_test.go
+++ b/integration/storage_integration_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/tarantool/go-storage/v2/kv"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 const configPrefix = "/config/"

--- a/integration/tarantool_integration_test.go
+++ b/integration/tarantool_integration_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/internal/testutil"
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/internal/testutil"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 // bigTarantoolConfig is a realistic multi-group, multi-replicaset

--- a/internal/environ/environ_test.go
+++ b/internal/environ/environ_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/internal/environ"
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2/internal/environ"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func checkByPath(t *testing.T, root *tree.Node, keyPath string, expectedValue any) {

--- a/internal/structtag/structtag_test.go
+++ b/internal/structtag/structtag_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/internal/structtag"
+	"github.com/tarantool/go-config/v2/internal/structtag"
 )
 
 func TestParse(t *testing.T) {

--- a/internal/testutil/drain_test.go
+++ b/internal/testutil/drain_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 )
 
 func TestDrain_ClosedChannel(t *testing.T) {

--- a/internal/testutil/mock_storage_test.go
+++ b/internal/testutil/mock_storage_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/internal/testutil"
+	"github.com/tarantool/go-config/v2/internal/testutil"
 	"github.com/tarantool/go-storage/v2/kv"
 	"github.com/tarantool/go-storage/v2/operation"
 )

--- a/keypath.go
+++ b/keypath.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 // KeyPath represents a hierarchical key.

--- a/keypath/keypath_test.go
+++ b/keypath/keypath_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 func formatTestName(in string) string {

--- a/keypath_test.go
+++ b/keypath_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/v2"
 )
 
 func formatTestName(in string) string {

--- a/layered_extra_test.go
+++ b/layered_extra_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/meta"
 )
 
 // ---------------------------------------------------------------------------

--- a/marshal.go
+++ b/marshal.go
@@ -6,8 +6,8 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/tree"
 	"go.yaml.in/yaml/v3"
 )
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
 )
 
 // buildFromYAML writes data to a temp file and returns a built MutableConfig.

--- a/merge.go
+++ b/merge.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // isNumericString reports whether str consists only of ASCII digits.

--- a/merge_test.go
+++ b/merge_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestMergeCollector_Success(t *testing.T) {

--- a/merge_tree_test.go
+++ b/merge_tree_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 const (

--- a/merger_custom_test.go
+++ b/merger_custom_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // countingMerger counts the number of MergeValue calls.

--- a/meta/info.go
+++ b/meta/info.go
@@ -1,7 +1,7 @@
 package meta
 
 import (
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 // Info contains metadata about a value in the configuration.

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/meta"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/meta"
 )
 
 func TestSourceType_ConstantsExist(t *testing.T) {

--- a/mutable_mutation_test.go
+++ b/mutable_mutation_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/v2"
 )
 
 func TestMutableConfig_Set_YAMLRoundTrip(t *testing.T) {

--- a/omap/orderedmap_test.go
+++ b/omap/orderedmap_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/internal/testutil"
-	"github.com/tarantool/go-config/omap"
+	"github.com/tarantool/go-config/v2/internal/testutil"
+	"github.com/tarantool/go-config/v2/omap"
 )
 
 func TestOrderedMap_Set_Get_single(t *testing.T) {

--- a/tarantool/builder.go
+++ b/tarantool/builder.go
@@ -9,10 +9,10 @@ import (
 	"path"
 	"strings"
 
-	config "github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/collectors"
-	"github.com/tarantool/go-config/tarantool/internal/envpath"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	config "github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/collectors"
+	"github.com/tarantool/go-config/v2/tarantool/internal/envpath"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 	"github.com/tarantool/go-storage/v2/integrity"
 )
 

--- a/tarantool/builder_coverage_test.go
+++ b/tarantool/builder_coverage_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/internal/testutil"
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/internal/testutil"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 func TestWithStorageKey(t *testing.T) {

--- a/tarantool/builder_envignore_test.go
+++ b/tarantool/builder_envignore_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 func TestBuild_EnvIgnore_ExactMatch(t *testing.T) {

--- a/tarantool/builder_envschema_test.go
+++ b/tarantool/builder_envschema_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tarantool"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tarantool"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 const fixtureSchemaPath = "testdata/config.schema.json"

--- a/tarantool/builder_test.go
+++ b/tarantool/builder_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/internal/testutil"
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/internal/testutil"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 func TestNew(t *testing.T) {

--- a/tarantool/example_test.go
+++ b/tarantool/example_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 func ExampleBuilder_WithConfigFile() {

--- a/tarantool/internal/envpath/envpath.go
+++ b/tarantool/internal/envpath/envpath.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tarantool/go-config"
+	"github.com/tarantool/go-config/v2"
 )
 
 // Node is a trie node keyed by lowercased schema segment names.

--- a/tarantool/internal/envpath/envpath_test.go
+++ b/tarantool/internal/envpath/envpath_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tarantool/internal/envpath"
+	"github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tarantool/internal/envpath"
 )
 
 func loadFixtureSchema(t *testing.T) []byte {

--- a/tarantool/schema_http_test.go
+++ b/tarantool/schema_http_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	config "github.com/tarantool/go-config"
+	config "github.com/tarantool/go-config/v2"
 )
 
 func TestHTTPFetchSchema_RequestShape(t *testing.T) {

--- a/tarantool/schema_public_test.go
+++ b/tarantool/schema_public_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	config "github.com/tarantool/go-config"
-	"github.com/tarantool/go-config/tarantool"
+	config "github.com/tarantool/go-config/v2"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 var errSchemaTransport = errors.New("schema transport failed")

--- a/tarantool/schemas_internal_test.go
+++ b/tarantool/schemas_internal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/internal/race"
+	"github.com/tarantool/go-config/v2/internal/race"
 )
 
 // Replaces the eager init-time validation: ensures every shipped schema

--- a/tarantool/schemas_test.go
+++ b/tarantool/schemas_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/tarantool"
+	"github.com/tarantool/go-config/v2/tarantool"
 )
 
 var minimalValidSchema = []byte(`{"type":"object"}`) //nolint:gochecknoglobals // test fixtures

--- a/tree/convert_test.go
+++ b/tree/convert_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestToAny_Leaf(t *testing.T) {

--- a/tree/node.go
+++ b/tree/node.go
@@ -3,8 +3,8 @@ package tree
 import (
 	"slices"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/omap"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/omap"
 )
 
 // Value represents a configuration value.

--- a/tree/node_test.go
+++ b/tree/node_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestNode_Set_Get_leaf(t *testing.T) {

--- a/tree/range_test.go
+++ b/tree/range_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 func TestPosition_Structure(t *testing.T) {

--- a/tree/value.go
+++ b/tree/value.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/tarantool/go-config/internal/structtag"
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/value"
+	"github.com/tarantool/go-config/v2/internal/structtag"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/value"
 )
 
 // valueImpl is the internal implementation of the value.Value interface.

--- a/tree/value_test.go
+++ b/tree/value_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 var _ = math.MaxInt64

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 // ValidationError describes a single validation error.

--- a/validator/range.go
+++ b/validator/range.go
@@ -1,7 +1,7 @@
 package validator
 
 import (
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Range describes a range in source file for highlighting.

--- a/validator/range_test.go
+++ b/validator/range_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 func TestRangeFromTree_Basic(t *testing.T) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,7 +1,7 @@
 package validator
 
 import (
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 // Validator validates configuration against a schema.

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 var _ error = (*validator.ValidationError)(nil)

--- a/validators/jsonschema/coerce_scalar_test.go
+++ b/validators/jsonschema/coerce_scalar_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 // scalarSchema mirrors a config with strict scalar types plus a union field.

--- a/validators/jsonschema/coerce_test.go
+++ b/validators/jsonschema/coerce_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 // tlsSchema mirrors the shape that breaks TCM: a scalar string field, an array

--- a/validators/jsonschema/convert.go
+++ b/validators/jsonschema/convert.go
@@ -3,7 +3,7 @@ package jsonschema
 import (
 	"strings"
 
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 // jsonPointerToKeyPath converts "/path/to/field" to KeyPath{"path", "to", "field"}.

--- a/validators/jsonschema/convert_test.go
+++ b/validators/jsonschema/convert_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tarantool/go-config/keypath"
+	"github.com/tarantool/go-config/v2/keypath"
 )
 
 func TestJsonPointerToKeyPath(t *testing.T) {

--- a/validators/jsonschema/errors.go
+++ b/validators/jsonschema/errors.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/kaptinlin/jsonschema"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 // validationErrors collects validation errors during JSON Schema validation.

--- a/validators/jsonschema/errors_test.go
+++ b/validators/jsonschema/errors_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/kaptinlin/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 const (

--- a/validators/jsonschema/validator.go
+++ b/validators/jsonschema/validator.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/kaptinlin/jsonschema"
 
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validator"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validator"
 )
 
 // Validator validates configuration against JSON Schema.

--- a/validators/jsonschema/validator_test.go
+++ b/validators/jsonschema/validator_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/tree"
-	"github.com/tarantool/go-config/validators/jsonschema"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/tree"
+	"github.com/tarantool/go-config/v2/validators/jsonschema"
 )
 
 func TestNew_ValidSchema(t *testing.T) {

--- a/value.go
+++ b/value.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/value"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/value"
 )
 
 // SourceType defines the type of configuration source.

--- a/value/value.go
+++ b/value/value.go
@@ -1,6 +1,6 @@
 package value
 
-import "github.com/tarantool/go-config/meta"
+import "github.com/tarantool/go-config/v2/meta"
 
 // Value represents a single value in the configuration.
 type Value interface {

--- a/value/value_test.go
+++ b/value/value_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tarantool/go-config/keypath"
-	"github.com/tarantool/go-config/meta"
-	"github.com/tarantool/go-config/tree"
+	"github.com/tarantool/go-config/v2/keypath"
+	"github.com/tarantool/go-config/v2/meta"
+	"github.com/tarantool/go-config/v2/tree"
 )
 
 type mockValue struct {


### PR DESCRIPTION
This release bumps the project path to `github.com/tarantool/go-config/v2`.

### Changed

* Changed project path to `github.com/tarantool/go-config/v2`.